### PR TITLE
Add pre-commit hooks configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lint-sol
+        name: "lint core sol"
+        entry: /usr/bin/env bash -c "cd core/ && npm run lint:sol"
+        files: '\.sol$'
+        language: script
+        description: "Checks solidity code according to the package's linter configuration"
+      - id: lint-eslint
+        name: "lint core ts/js"
+        entry: /usr/bin/env bash -c "cd core/ && npm run lint:eslint"
+        files: '\.(ts|js)$'
+        language: script
+        description: "Checks TS/JS code according to the package's linter configuration"
+      - id: lint-config
+        name: "lint core json/yaml"
+        entry: /usr/bin/env bash -c "cd core/ && npm run lint:config"
+        files: '\.(json|yaml)$'
+        language: script
+        description: "Checks JSON/YAML code according to the package's linter configuration"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # litmus
 Bitcoin Liquid Staking
+
+# Development
+
+## Pre-commit Hooks
+
+Developers are encouraged to use [pre-commit](https://pre-commit.com/) hooks to
+automatically discover code issues, before they submit the code.
+
+To setup the hooks follow the steps:
+
+1. Install `pre-commit` tool:
+    ```sh
+    brew install pre-commit
+    ```
+
+2. Install the hooks for the repository:
+    ```sh
+    pre-commit install
+    ```


### PR DESCRIPTION
The pre-commit hooks are used to run code formatting checks before the code is submitted to the repository with `git commit` command.

To setup the hooks follow the steps:

1. Install `pre-commit` tool: 
```sh
brew install pre-commit
```

3. Install the hooks for the repository: 
```sh
pre-commit install
```

Depends on: https://github.com/thesis/litmus/pull/1