### PR TITLE
Token Staking

### DIFF
--- a/core/contracts/staking/TokenStaking.sol
+++ b/core/contracts/staking/TokenStaking.sol
@@ -73,6 +73,7 @@ contract TokenStaking is IReceiveApproval {
 
         balanceOf[staker] += amount;
 
+        // TODO: Mint stBTC token.
         emit Staked(staker, amount);
         token.safeTransferFrom(staker, address(this), amount);
     }


### PR DESCRIPTION
Depends on: #1
Ref: #2 

This PR creates the Token Staking contract - a contract for a specified standard ERC20 token. A holder of the specified token can stake its tokens to this contract and recover the stake after undelegation period is over. This contract also supports `approveAndCall`/`receiveApproval` pattern so users can stake in one transaction (instead of 2: `Token.approve` + `TokenStaking.stake`). The initial implementation of staking tracks the staked balance and transfers the staked amount to the staking contract.