### PR TITLE
Add a guide for dApp

### DIFF
--- a/dapp/README.md
+++ b/dapp/README.md
@@ -1,10 +1,26 @@
 # Acre dApp
 
-## Installation
+The application is compatible with Ledger Live and allows people to earn yield on their Bitcoin via yield farming on Ethereum.
 
-1.  Install dependencies and start the app.
-    ```bash
+This project was bootstrapped with [Create Vite](https://github.com/vitejs/vite/tree/main/packages/create-vite).
+
+## Quickstart
+
+Install dependencies and start the app.
+
+ ```bash
     yarn install
     yarn start
-    ```
-2.  Open [http://localhost:5173](http://localhost:5173) to view it in the browser.
+```
+
+Once the build is running, you can import the manifest on desktop:
+
+1. [Install Ledger Live Desktop](https://www.ledger.com/ledger-live)
+2. Enable the Developer mode
+
+    Go to the **Settings -> About** section, and click 10 times on the Ledger Live version. A new Developer section appears in the settings menu. Turn on **Enable platform dev** tools to use the developer tools window to inspect your app.
+3. Add your manifest
+
+    Click on Browse next to **Add a local app** and select the manifest file. The app is now visible in the menu.
+
+If you have any problems, take a look [here](https://developers.ledger.com/docs/non-dapp/tutorial/3-import/#desktop).


### PR DESCRIPTION
The description of how to run the app should be clearer. This information should be included in the `README` file. 

This PR adds a guide how to open the dApp in to ledger live. 