### PR TITLE
Configure prettier.ignorePath for Visual Studio Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "eslint.workingDirectories": [{ "mode": "auto" }]
+  "eslint.workingDirectories": [{ "mode": "auto" }],
+  "prettier.ignorePath": ""
 }


### PR DESCRIPTION
In our monorepo we defined seprate prettier configurations for the modules and the root directory. VS Code has problems resolving the prettier ignore configuration, and reads root's file by default, which ignores the modules from formatting.
Here we specify no file to use with prettier ignore configuration so VS Code can still work.