### PR TITLE
Public hoist eslint plugins

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
 public-hoist-pattern[]=@chakra-ui/*
+# This is a workaround for VSCode's Eslint extension not loading plugins correctly,
+# see: https://github.com/pnpm/pnpm/issues/5447
+public-hoist-pattern[]=*eslint-plugin*


### PR DESCRIPTION
Eslint in Visual Studio Code doesn't work properly in monorepo pnpm setup due to a problem reported in
https://github.com/pnpm/pnpm/issues/5447.

As a workaround we public hoist the eslint plugins.