### PR TITLE
Add missing snapshot restorer to `deposit` tests

### DIFF
--- a/core/test/Acre.test.ts
+++ b/core/test/Acre.test.ts
@@ -924,9 +924,15 @@ describe("Acre", () => {
   describe("deposit", () => {
     let amountToDeposit: bigint
     let minimumDepositAmount: bigint
+    let snapshot: SnapshotRestorer
 
     beforeEach(async () => {
+      snapshot = await takeSnapshot()
       minimumDepositAmount = await acre.minimumDepositAmount()
+    })
+
+    afterEach(async () => {
+      await snapshot.restore()
     })
 
     context("when the deposit amount is less than minimum", () => {


### PR DESCRIPTION
Ref: https://github.com/thesis/acre/pull/68#discussion_r1438176681

Add missing snapshot restorer to `deposit` tests according to the existing pattern.