### PR TITLE
Imports update for component themes

### DIFF
--- a/dapp/src/theme/Alert.ts
+++ b/dapp/src/theme/Alert.ts
@@ -72,6 +72,4 @@ const variants = {
   subtle: variantSubtle,
 }
 
-const Alert = defineMultiStyleConfig({ baseStyle, variants })
-
-export default Alert
+export const alertTheme = defineMultiStyleConfig({ baseStyle, variants })

--- a/dapp/src/theme/Button.ts
+++ b/dapp/src/theme/Button.ts
@@ -4,7 +4,7 @@ import {
 } from "@chakra-ui/react"
 
 // TODO: Update the button styles correctly when ready
-const Button: ComponentSingleStyleConfig = {
+export const buttonTheme: ComponentSingleStyleConfig = {
   baseStyle: {
     size: "md",
     borderRadius: "lg",
@@ -79,5 +79,3 @@ const Button: ComponentSingleStyleConfig = {
     },
   },
 }
-
-export default Button

--- a/dapp/src/theme/Card.ts
+++ b/dapp/src/theme/Card.ts
@@ -3,7 +3,7 @@ import {
   StyleFunctionProps,
 } from "@chakra-ui/react"
 
-const Card: ComponentSingleStyleConfig = {
+export const cardTheme: ComponentSingleStyleConfig = {
   baseStyle: {
     container: {
       boxShadow: "none",
@@ -39,5 +39,3 @@ const Card: ComponentSingleStyleConfig = {
     size: "lg",
   },
 }
-
-export default Card

--- a/dapp/src/theme/CurrencyBalance.ts
+++ b/dapp/src/theme/CurrencyBalance.ts
@@ -101,6 +101,8 @@ const sizes = {
   xl: sizeXl,
 }
 
-const CurrencyBalance = defineMultiStyleConfig({ baseStyle, variants, sizes })
-
-export default CurrencyBalance
+export const currencyBalanceTheme = defineMultiStyleConfig({
+  baseStyle,
+  variants,
+  sizes,
+})

--- a/dapp/src/theme/Drawer.ts
+++ b/dapp/src/theme/Drawer.ts
@@ -29,6 +29,4 @@ const baseStyle = definePartsStyle({
   overlay: baseStyleOverlay,
 })
 
-const Drawer = defineMultiStyleConfig({ baseStyle })
-
-export default Drawer
+export const drawerTheme = defineMultiStyleConfig({ baseStyle })

--- a/dapp/src/theme/Form.ts
+++ b/dapp/src/theme/Form.ts
@@ -16,6 +16,4 @@ const baseStyle = definePartsStyle({
   helperText: baseStyleHelperText,
 })
 
-const Form = defineMultiStyleConfig({ baseStyle })
-
-export default Form
+export const formTheme = defineMultiStyleConfig({ baseStyle })

--- a/dapp/src/theme/FormError.ts
+++ b/dapp/src/theme/FormError.ts
@@ -14,6 +14,4 @@ const baseStyle = definePartsStyle({
   text: baseStyleText,
 })
 
-const FormError = defineMultiStyleConfig({ baseStyle })
-
-export default FormError
+export const formErrorTheme = defineMultiStyleConfig({ baseStyle })

--- a/dapp/src/theme/FormLabel.ts
+++ b/dapp/src/theme/FormLabel.ts
@@ -20,6 +20,4 @@ const sizes = {
   lg: sizeLg,
 }
 
-const FormLabel = defineStyleConfig({ baseStyle, sizes })
-
-export default FormLabel
+export const formLabelTheme = defineStyleConfig({ baseStyle, sizes })

--- a/dapp/src/theme/Heading.ts
+++ b/dapp/src/theme/Heading.ts
@@ -1,6 +1,6 @@
 import { ComponentSingleStyleConfig } from "@chakra-ui/react"
 
-const Heading: ComponentSingleStyleConfig = {
+export const headingTheme: ComponentSingleStyleConfig = {
   sizes: {
     "7xl": {
       fontSize: "7xl",
@@ -28,5 +28,3 @@ const Heading: ComponentSingleStyleConfig = {
     },
   },
 }
-
-export default Heading

--- a/dapp/src/theme/Input.ts
+++ b/dapp/src/theme/Input.ts
@@ -39,6 +39,4 @@ const variants = {
   balance: variantBalance,
 }
 
-const Input = defineMultiStyleConfig({ variants })
-
-export default Input
+export const inputTheme = defineMultiStyleConfig({ variants })

--- a/dapp/src/theme/Modal.ts
+++ b/dapp/src/theme/Modal.ts
@@ -51,6 +51,4 @@ const baseStyle = definePartsStyle({
   body: baseStyleBody,
 })
 
-const Modal = defineMultiStyleConfig({ baseStyle })
-
-export default Modal
+export const modalTheme = defineMultiStyleConfig({ baseStyle })

--- a/dapp/src/theme/Sidebar.ts
+++ b/dapp/src/theme/Sidebar.ts
@@ -34,6 +34,4 @@ const baseStyle = definePartsStyle({
   sidebar: baseStyleSidebar,
 })
 
-const Sidebar = defineMultiStyleConfig({ baseStyle })
-
-export default Sidebar
+export const sidebarTheme = defineMultiStyleConfig({ baseStyle })

--- a/dapp/src/theme/Stepper.ts
+++ b/dapp/src/theme/Stepper.ts
@@ -73,6 +73,4 @@ const baseStyle = definePartsStyle((props) => ({
   separator: baseStyleSeparator(props),
 }))
 
-const Stepper = defineMultiStyleConfig({ baseStyle })
-
-export default Stepper
+export const stepperTheme = defineMultiStyleConfig({ baseStyle })

--- a/dapp/src/theme/Switch.ts
+++ b/dapp/src/theme/Switch.ts
@@ -1,6 +1,6 @@
 import { ComponentSingleStyleConfig } from "@chakra-ui/react"
 
-const Switch: ComponentSingleStyleConfig = {
+export const switchTheme: ComponentSingleStyleConfig = {
   baseStyle: {
     track: {
       bg: "grey.700",
@@ -10,5 +10,3 @@ const Switch: ComponentSingleStyleConfig = {
     },
   },
 }
-
-export default Switch

--- a/dapp/src/theme/Tabs.ts
+++ b/dapp/src/theme/Tabs.ts
@@ -46,6 +46,4 @@ const variants = {
   underline: variantUnderline,
 }
 
-const Tabs = defineMultiStyleConfig({ baseStyle, variants })
-
-export default Tabs
+export const tabsTheme = defineMultiStyleConfig({ baseStyle, variants })

--- a/dapp/src/theme/TokenBalanceInput.ts
+++ b/dapp/src/theme/TokenBalanceInput.ts
@@ -26,6 +26,4 @@ const baseStyle = definePartsStyle({
   balance: baseStyleBalance,
 })
 
-const TokenBalanceInput = defineMultiStyleConfig({ baseStyle })
-
-export default TokenBalanceInput
+export const tokenBalanceInputTheme = defineMultiStyleConfig({ baseStyle })

--- a/dapp/src/theme/Tooltip.ts
+++ b/dapp/src/theme/Tooltip.ts
@@ -14,12 +14,10 @@ ChakraTooltip.defaultProps = { ...ChakraTooltip.defaultProps, hasArrow: true }
 // https://github.com/chakra-ui/chakra-ui/issues/4695#issuecomment-991023319
 const $arrowBg = cssVar("popper-arrow-bg")
 
-const Tooltip: ComponentSingleStyleConfig = {
+export const tooltipTheme: ComponentSingleStyleConfig = {
   baseStyle: {
     borderRadius: "md",
     bg: "grey.700",
     [$arrowBg.variable]: "colors.grey.700",
   },
 }
-
-export default Tooltip

--- a/dapp/src/theme/index.ts
+++ b/dapp/src/theme/index.ts
@@ -1,24 +1,24 @@
 import { StyleFunctionProps, extendTheme } from "@chakra-ui/react"
 import { mode } from "@chakra-ui/theme-tools"
-import Button from "./Button"
-import Switch from "./Switch"
+import { buttonTheme } from "./Button"
+import { switchTheme } from "./Switch"
 import { colors, fonts, lineHeights, semanticTokens, zIndices } from "./utils"
-import Drawer from "./Drawer"
-import Modal from "./Modal"
-import Card from "./Card"
-import Tooltip from "./Tooltip"
-import Heading from "./Heading"
-import Sidebar from "./Sidebar"
-import CurrencyBalance from "./CurrencyBalance"
-import TokenBalanceInput from "./TokenBalanceInput"
-import Input from "./Input"
-import Stepper from "./Stepper"
-import Alert from "./Alert"
-import Form from "./Form"
-import FormLabel from "./FormLabel"
-import FormError from "./FormError"
-import Tabs from "./Tabs"
-import { spinnerTheme as Spinner } from "./Spinner"
+import { drawerTheme } from "./Drawer"
+import { modalTheme } from "./Modal"
+import { cardTheme } from "./Card"
+import { tooltipTheme } from "./Tooltip"
+import { headingTheme } from "./Heading"
+import { sidebarTheme } from "./Sidebar"
+import { currencyBalanceTheme } from "./CurrencyBalance"
+import { tokenBalanceInputTheme } from "./TokenBalanceInput"
+import { inputTheme } from "./Input"
+import { stepperTheme } from "./Stepper"
+import { alertTheme } from "./Alert"
+import { formTheme } from "./Form"
+import { formLabelTheme } from "./FormLabel"
+import { formErrorTheme } from "./FormError"
+import { tabsTheme } from "./Tabs"
+import { spinnerTheme } from "./Spinner"
 
 const defaultTheme = {
   colors,
@@ -36,24 +36,24 @@ const defaultTheme = {
     }),
   },
   components: {
-    Button,
-    Switch,
-    Drawer,
-    Sidebar,
-    Modal,
-    Heading,
-    CurrencyBalance,
-    Card,
-    Tooltip,
-    Input,
-    TokenBalanceInput,
-    Stepper,
-    Alert,
-    Form,
-    FormLabel,
-    FormError,
-    Tabs,
-    Spinner,
+    Alert: alertTheme,
+    Button: buttonTheme,
+    Card: cardTheme,
+    CurrencyBalance: currencyBalanceTheme,
+    Drawer: drawerTheme,
+    Form: formTheme,
+    FormLabel: formLabelTheme,
+    FormError: formErrorTheme,
+    Heading: headingTheme,
+    Input: inputTheme,
+    Modal: modalTheme,
+    Sidebar: sidebarTheme,
+    Spinner: spinnerTheme,
+    Stepper: stepperTheme,
+    Switch: switchTheme,
+    Tabs: tabsTheme,
+    TokenBalanceInput: tokenBalanceInputTheme,
+    Tooltip: tooltipTheme,
   },
 }
 


### PR DESCRIPTION
Closes: #139 

Changed default export theme to export const and updated naming convention themes consistent with the chakra-ui to represent what exactly export represents. 

Originally posted in https://github.com/thesis/acre/pull/105#discussion_r1441910575