### PR TITLE
Disable dark theme mode

### DIFF
--- a/dapp/src/DApp.tsx
+++ b/dapp/src/DApp.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Box, ChakraProvider } from "@chakra-ui/react"
-import { useDetectThemeMode, useSentry } from "./hooks"
+import { useSentry } from "./hooks"
 import theme from "./theme"
 import {
   DocsDrawerContextProvider,
@@ -15,7 +15,8 @@ import DocsDrawer from "./components/DocsDrawer"
 import GlobalStyles from "./components/GlobalStyles"
 
 function DApp() {
-  useDetectThemeMode()
+  // TODO: Let's uncomment when dark mode is ready
+  // useDetectThemeMode()
   useSentry()
 
   return (

--- a/dapp/src/theme/index.ts
+++ b/dapp/src/theme/index.ts
@@ -25,6 +25,10 @@ import { statusInfoTheme } from "./StatusInfo"
 import { linkTheme } from "./Link"
 
 const defaultTheme = {
+  // TODO: Remove when dark mode is ready
+  // Color mode should be detected by hook useDetectThemeMode
+  initialColorMode: "light",
+  useSystemColorMode: false,
   colors,
   fonts,
   lineHeights,


### PR DESCRIPTION
Currently, dark mode is not yet ready. Our app detects the theme in the ledger live app and sets it for dApp theme. Let's disable the black theme now and when ready revert this feature.

If you previously used a dark theme for the ledger live app you need to clear the storage for dApp. Use the following command in the console for dApp:

```
localStorage.clear()
```

<img width="1712" alt="Screenshot 2024-02-13 at 09 01 13" src="https://github.com/thesis/acre/assets/23117945/ae3b664f-41b0-4f71-b25a-52a85685adf0">

