### PR TITLE
Update actions to versions running on Node20 

### DIFF
--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/dapp.yaml
+++ b/.github/workflows/dapp.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-core-build.yaml
+++ b/.github/workflows/reusable-core-build.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-sdk-build.yaml
+++ b/.github/workflows/reusable-sdk-build.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
As per
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/,
GitHub has started a deprecation process for the GitHub Actions that run on
Node16. We're updating Actions that use this version of Node to newer versions,
running on Node20.

This will also help with fixing of the `Unable to download
artifact(s): Artifact not found for name: core-build` error that we got in CI,
as we had a mismatch of versions between the `actions/upload-artifact`
and `actions/download-artifact` actions.