### PR TITLE
Fix the upload step in the `core-deploy-testnet` job

### DIFF
--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -186,4 +186,5 @@ jobs:
         with:
           name: deployed-contracts-${{ github.event.inputs.environment }}
           path: |
-            deployments/${{ github.event.inputs.environment }}
+            core/deployments/${{ github.event.inputs.environment }}
+          if-no-files-found: error


### PR DESCRIPTION
The upload step of the `core-deploy-testnet` job was throwing a warning about no files being uploaded. This was because we had a misconfiguration of the path. In this commit/PR we're fixing the path and also adding a config that will cause a job failure if no files are found by the upload step.

A deployment job run on the code from this PR: https://github.com/thesis/acre/actions/runs/8141112287