### PR TITLE
CI integration test

### DIFF
--- a/.github/workflows/solidity.yaml
+++ b/.github/workflows/solidity.yaml
@@ -140,8 +140,10 @@ jobs:
           path: solidity/
 
       - name: Run Hardhat Node
+        env:
+          MAINNET_RPC_URL: ${{ secrets.MAINNET_CHAIN_API_URL }}
         run: |
-          MAINNET_RPC_URL=${{ secrets.MAINNET_CHAIN_API_URL }} pnpm node:forking &
+          pnpm node:forking &
           while [[ -z $(lsof -i :8545 -t) ]]; do echo "Waiting for port 8545 to be open..."; sleep 10; done
 
       - name: Run Integration Tests


### PR DESCRIPTION
Depends on https://github.com/thesis/acre/pull/372

Adding CI config `solidity-integration-test` to run integration tests against forked mainnet by the local hardhat node.