### PR TITLE
Round up depositor fee calculation

### DIFF
--- a/solidity/contracts/BitcoinDepositor.sol
+++ b/solidity/contracts/BitcoinDepositor.sol
@@ -261,7 +261,7 @@ contract BitcoinDepositor is AbstractTBTCDepositor, Ownable2StepUpgradeable {
         // Compute depositor fee. The fee is calculated based on the initial funding
         // transaction amount, before the tBTC protocol network fees were taken.
         uint256 depositorFee = depositorFeeDivisor > 0
-            ? (initialAmount / depositorFeeDivisor)
+            ? Math.ceilDiv(initialAmount, depositorFeeDivisor)
             : 0;
 
         // Ensure the depositor fee does not exceed the approximate minted tBTC


### PR DESCRIPTION
Due to the incorrect rounding, unless the bridged amount is a multiple of the depositorFeeDivisor, a loss of 1 wei of fees will occur on every bridging attempt. Additionally, depositorFeeDivisor - 1 tokens can be bridged without any fees.

To avoid that we round up the calculation.