### PR TITLE
Revert "Pausing token transfers upon pausing the protocol"

### DIFF
--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -355,21 +355,6 @@ contract stBTC is ERC4626Fees, PausableOwnable {
         return convertToAssets(balanceOf(account));
     }
 
-    /// @dev Transfers a `value` amount of tokens from `from` to `to`, or
-    ///      alternatively mints (or burns) if `from` (or `to`) is the zero
-    ///      address. All customizations to transfers, mints, and burns should
-    ///      be done by overriding this function.
-    /// @param from Sender of tokens.
-    /// @param to Receiver of tokens.
-    /// @param value Amount of tokens to transfer.
-    function _update(
-        address from,
-        address to,
-        uint256 value
-    ) internal override whenNotPaused {
-        super._update(from, to, value);
-    }
-
     /// @return Returns entry fee basis point used in deposits.
     function _entryFeeBasisPoints() internal view override returns (uint256) {
         return entryFeeBasisPoints;

--- a/solidity/test/stBTC.test.ts
+++ b/solidity/test/stBTC.test.ts
@@ -1868,25 +1868,6 @@ describe("stBTC", () => {
       it("should return 0 when calling maxWithdraw", async () => {
         expect(await stbtc.maxWithdraw(depositor1)).to.be.eq(0)
       })
-
-      it("should pause transfers", async () => {
-        await expect(
-          stbtc.connect(depositor1).transfer(depositor2, amount),
-        ).to.be.revertedWithCustomError(stbtc, "EnforcedPause")
-      })
-
-      it("should pause transfersFrom", async () => {
-        await expect(
-          stbtc
-            .connect(depositor1)
-            .approve(depositor2.address, amount)
-            .then(() =>
-              stbtc
-                .connect(depositor2)
-                .transferFrom(depositor1, depositor2, amount),
-            ),
-        ).to.be.revertedWithCustomError(stbtc, "EnforcedPause")
-      })
     })
   })
 


### PR DESCRIPTION
This reverts commit 2c94f79332cf4600ac79fab49c721c90e92d250c.

Reverts PR https://github.com/thesis/acre/pull/388 We do not want to pause already minted `stBTC` transfers upon pausing Acre protocol.