### PR TITLE
Suggestion 3: Adding missing check for ownership of tBTC token

### DIFF
--- a/solidity/contracts/BitcoinRedeemer.sol
+++ b/solidity/contracts/BitcoinRedeemer.sol
@@ -61,6 +61,9 @@ contract BitcoinRedeemer is Ownable2StepUpgradeable, IReceiveApproval {
     /// Reverts when approveAndCall to tBTC contract fails.
     error ApproveAndCallFailed();
 
+    /// Reverts if the new TBTCVault contract is not tBTC token owner.
+    error NotTbtcTokenOwner();
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -116,6 +119,10 @@ contract BitcoinRedeemer is Ownable2StepUpgradeable, IReceiveApproval {
     function updateTbtcVault(address newTbtcVault) external onlyOwner {
         if (newTbtcVault == address(0)) {
             revert ZeroAddress();
+        }
+
+        if (newTbtcVault != tbtcToken.owner()) {
+            revert NotTbtcTokenOwner();
         }
 
         emit TbtcVaultUpdated(tbtcVault, newTbtcVault);

--- a/solidity/test/BitcoinRedeemer.test.ts
+++ b/solidity/test/BitcoinRedeemer.test.ts
@@ -442,7 +442,16 @@ describe("BitcoinRedeemer", () => {
         })
       })
 
-      context("when a new treasury is an allowed address", () => {
+      context("when a new tbtc vault is not tBTC token owner", () => {
+        it("should revert", async () => {
+          const newTbtcVault = await ethers.Wallet.createRandom().getAddress()
+          await expect(
+            bitcoinRedeemer.connect(governance).updateTbtcVault(newTbtcVault),
+          ).to.be.revertedWithCustomError(bitcoinRedeemer, "NotTbtcTokenOwner")
+        })
+      })
+
+      context("when a new tbtc vault is an allowed address", () => {
         let oldTbtcVault: string
         let newTbtcVault: string
         let tx: ContractTransactionResponse
@@ -450,6 +459,7 @@ describe("BitcoinRedeemer", () => {
         before(async () => {
           oldTbtcVault = await bitcoinRedeemer.tbtcVault()
           newTbtcVault = await ethers.Wallet.createRandom().getAddress()
+          await tbtc.setOwner(newTbtcVault)
 
           tx = await bitcoinRedeemer
             .connect(governance)


### PR DESCRIPTION
Added a missing check for ownership of tBTC token when updating the tbtcVault address.