### PR TITLE
Replace Bitcoin block explorer links

### DIFF
--- a/dapp/src/constants/chains.ts
+++ b/dapp/src/constants/chains.ts
@@ -1,10 +1,20 @@
 import { Chain } from "#/types"
 import { EthereumNetwork, BitcoinNetwork } from "@acre-btc/sdk"
 
-export const BLOCK_EXPLORER: Record<Chain, { title: string; url: string }> = {
-  ethereum: { title: "Etherscan", url: "https://etherscan.io" },
-  bitcoin: { title: "Blockstream", url: "https://blockstream.info" },
+const BLOCK_EXPLORER_TESTNET = {
+  ethereum: { title: "Etherscan", url: "https://sepolia.etherscan.io" },
+  bitcoin: { title: "Mempool Space", url: "https://mempool.space/testnet" },
 }
+
+const BLOCK_EXPLORER_MAINNET = {
+  ethereum: { title: "Etherscan", url: "https://etherscan.io" },
+  bitcoin: { title: "Mempool Space", url: "https://mempool.space" },
+}
+
+export const BLOCK_EXPLORER: Record<Chain, { title: string; url: string }> =
+  import.meta.env.VITE_USE_TESTNET === "true"
+    ? BLOCK_EXPLORER_TESTNET
+    : BLOCK_EXPLORER_MAINNET
 
 export const ETHEREUM_NETWORK: EthereumNetwork =
   import.meta.env.VITE_USE_TESTNET === "true" ? "sepolia" : "mainnet"


### PR DESCRIPTION
Closes https://github.com/thesis/acre/issues/328

This PR adds a missing block explorer for the testnet and replaces Bitcoin block explorer links from Blockstream to mempool.space.