### PR TITLE
DO NOT MERGE: Dirty prototype of nonfungible withdrawals

### DIFF
--- a/solidity/contracts/lib/ERC4626Nonfungible.sol
+++ b/solidity/contracts/lib/ERC4626Nonfungible.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {ERC4626Fees} from "./ERC4626Fees.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+/// @dev A dirty prototype vault with entry/exit fees and non-fungible
+/// withdrawals
+abstract contract ERC4626Nonfungible is ERC4626Fees {
+    using Math for uint256;
+
+    mapping(address => uint256) public deposited;
+
+    // === Overrides ===
+    //
+    /// @dev
+    function _deposit(
+        address caller,
+        address receiver,
+        uint256 assets,
+        uint256 shares
+    ) internal virtual override {
+        super._deposit(caller, receiver, assets, shares);
+
+        deposited[receiver] += assets;
+    }
+
+    /// @dev
+    function _withdraw(
+        address caller,
+        address receiver,
+        address owner,
+        uint256 assets,
+        uint256 shares
+    ) internal virtual override {
+        super._withdraw(caller, receiver, owner, assets, shares);
+
+        // XXX should revert if deposit receiver != an owner of same or less
+        // assets
+        deposited[owner] -= assets;
+    }
+}

--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@thesis-co/solidity-contracts/contracts/token/IReceiveApproval.sol";
 
 import "./PausableOwnable.sol";
-import "./lib/ERC4626Fees.sol";
+import "./lib/ERC4626Nonfungible.sol";
 import "./interfaces/IDispatcher.sol";
 import {ZeroAddress} from "./utils/Errors.sol";
 
@@ -21,7 +21,7 @@ import {ZeroAddress} from "./utils/Errors.sol";
 ///      burning of shares (stBTC), which are represented as standard ERC20
 ///      tokens, providing a seamless exchange with tBTC tokens.
 // slither-disable-next-line missing-inheritance
-contract stBTC is ERC4626Fees, PausableOwnable {
+contract stBTC is ERC4626Nonfungible, PausableOwnable {
     using SafeERC20 for IERC20;
 
     /// Dispatcher contract that routes tBTC from stBTC to a given allocation


### PR DESCRIPTION
I haven't tested this code! Just throwing it up as a quick example for the stBTC discussion.

The idea here is that you can only withdraw from the vault if you have first deposited as much or more as your withdrawal.

We'd want this capability to be temporary — it should be flipped off later. But launching with it (or something similar) would mean anyone who bought stBTC on the open market or who got it via the Mezo deposit portal would be unable to redeem for BTC... meaning only Acre depositors can redeem.