### PR TITLE
Fix  the condition issue for `OKX_WALLET_ENABLED` feature flag

### DIFF
--- a/dapp/src/components/ConnectWalletModal/index.tsx
+++ b/dapp/src/components/ConnectWalletModal/index.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from "react"
 import { ModalBody, ModalHeader, ModalCloseButton } from "@chakra-ui/react"
 import { useConnectors, useWalletConnectionError } from "#/hooks"
-import { OrangeKitConnector } from "#/types"
-import { BaseModalProps, OnSuccessCallback } from "#/types"
+import { OrangeKitConnector, BaseModalProps, OnSuccessCallback } from "#/types"
 import { featureFlags } from "#/constants"
 import withBaseModal from "../ModalRoot/withBaseModal"
 import ConnectWalletButton from "./ConnectWalletButton"
 import ConnectWalletErrorAlert from "./ConnectWalletErrorAlert"
 
 const disabledConnectorIds = [
-  featureFlags.OKX_WALLET_ENABLED ? "orangekit-okx" : "",
+  !featureFlags.OKX_WALLET_ENABLED ? "orangekit-okx" : "",
 ].filter(Boolean)
 
 export function ConnectWalletModalBase({


### PR DESCRIPTION
This PR fixes an incorrect condition for disabled connectors. Previously, even though `VITE_FEATURE_FLAG_OKX_WALLET_ENABLED` was set to true, the OKX wallet was disabled.