### PR TITLE
Handle withdrawal finalization in subgraph

### DIFF
--- a/subgraph/src/tbtc-bridge.ts
+++ b/subgraph/src/tbtc-bridge.ts
@@ -13,7 +13,11 @@ import {
   RedemptionsCompleted,
   SubmitRedemptionProofCall,
 } from "../generated/TbtcBridge/TbtcBridge"
-import { buildRedemptionKey, toBitcoinTxId } from "./tbtc-utils"
+import {
+  buildRedemptionKey,
+  toBitcoinTxId,
+  buildRedemptionKeyFromRedeemerOutputScript,
+} from "./tbtc-utils"
 import {
   getOwnerFromRedemptionRequestedLog,
   getRedemptionRequestedLog,
@@ -38,7 +42,7 @@ export function handleRedemptionRequested(event: RedemptionRequested): void {
 
   const ownerEntity = getOrCreateDepositOwner(ownerId)
 
-  const redemptionKey = buildRedemptionKey(
+  const redemptionKey = buildRedemptionKeyFromRedeemerOutputScript(
     event.params.redeemerOutputScript,
     event.params.walletPubKeyHash,
   )
@@ -144,8 +148,7 @@ export function handleSubmitRedemptionProofCall(
   // so we need to jump over 1+2 bytes of compactSize uint.
   let outputStartingIndex = outputsCompactSizeUintLength.plus(BigInt.fromI32(1))
 
-  // eslint-disable-next-line no-plusplus
-  for (let i: i32 = 0; i < outputsCount; i++) {
+  for (let i: i32 = 0; i < outputsCount; i += 1) {
     const outputLength = BitcoinUtils.determineOutputLengthAt(
       outputVector,
       outputStartingIndex,

--- a/subgraph/src/tbtc-utils.ts
+++ b/subgraph/src/tbtc-utils.ts
@@ -57,19 +57,28 @@ export function findBitcoinTransactionIdFromTransactionReceipt(
 }
 
 /**
- * keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)
- * */
+ * keccak256(scriptHash | walletPubKeyHash)
+ */
 export function buildRedemptionKey(
+  scriptHash: ByteArray,
+  walletPublicKeyHash: ByteArray,
+): string {
+  const data = new Uint8Array(scriptHash.length + walletPublicKeyHash.length)
+
+  data.set(scriptHash, 0)
+  data.set(walletPublicKeyHash, scriptHash.length)
+
+  return crypto.keccak256(Bytes.fromUint8Array(data)).toHexString()
+}
+
+/**
+ * keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)
+ */
+export function buildRedemptionKeyFromRedeemerOutputScript(
   redeemerOutputScript: ByteArray,
   walletPublicKeyHash: ByteArray,
 ): string {
   const scriptHashArray = crypto.keccak256(redeemerOutputScript)
-  const data = new Uint8Array(
-    scriptHashArray.length + walletPublicKeyHash.length,
-  )
 
-  data.set(scriptHashArray, 0)
-  data.set(walletPublicKeyHash, scriptHashArray.length)
-
-  return crypto.keccak256(Bytes.fromUint8Array(data)).toHexString()
+  return buildRedemptionKey(scriptHashArray, walletPublicKeyHash)
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -56,6 +56,7 @@ dataSources:
         - Withdraw
         - Event
         - RedemptionKeyCounter
+        - RedemptionsCompletedEvent
       abis:
         - name: TbtcBridge
           file: ./abis/TbtcBridge.json


### PR DESCRIPTION
Closes: #562

Fix calculating the redemption key in `handleSubmitRedemptionProofCall` handler. In the previous implementation, we unnecessarily calculated the `keccak256` for the redeemer output script **hash** (`redeemerOutputScriptHash = keccak256(redeemerOutputScript)`). We already calculated the hash for the output script so we should build the redemption key in this way: `keccak256(redeemerOutputScriptHash | walletPubKeyHash)` not `keccak256(keccak256(redeemerOutputScriptHash) | walletPubKeyHash)`.

The testnet Acre graph has been deployed (not published) in the graph studio as `v0.0.7`.