### PR TITLE
Show transaction details when user sets value by max button

### DIFF
--- a/dapp/src/components/shared/Form/FormTokenBalanceInput.tsx
+++ b/dapp/src/components/shared/Form/FormTokenBalanceInput.tsx
@@ -16,9 +16,10 @@ export function FormTokenBalanceInput({
 
   const setAmount = useCallback(
     (value?: bigint) => {
+      if (!meta.touched) logPromiseFailure(helpers.setTouched(true))
       logPromiseFailure(helpers.setValue(value))
     },
-    [helpers],
+    [helpers, meta.touched],
   )
 
   useEffect(() => {


### PR DESCRIPTION

In the withdrawal forms, the user has the option to select the entire balance by the max button. Previously, we did not show transaction details because the field was not set to be touched. By setting that the field has been touched we will calculate the details of the transaction such as the fee and the final amount the user will receive.

### UI

**Before**


https://github.com/user-attachments/assets/1dccf262-2fb3-491f-8d1c-a41d87063b5b


**After**

https://github.com/user-attachments/assets/8f9aacae-9afe-4666-a7e6-577b23677eef


