### PR TITLE
Fix the `RedemptionCompleted` event id

### DIFF
--- a/subgraph/src/tbtc-bridge.ts
+++ b/subgraph/src/tbtc-bridge.ts
@@ -190,7 +190,7 @@ export function handleSubmitRedemptionProofCall(
       withdraw.bitcoinTransactionId = bitcoinTransactionId
 
       const redemptionCompletedEvent = getOrCreateEvent(
-        `${call.transaction.hash.toHexString()}_RedemptionCompleted`,
+        `${call.transaction.hash.toHexString()}_${withdraw.id.toString()}_RedemptionCompleted`,
       )
 
       redemptionCompletedEvent.activity = withdraw.id


### PR DESCRIPTION
The `RedemptionCompleted` event id should be unique, so here we add the withdraw id to the `id` field. Previously we overwrote the activity id in the already existing `Event` entity, so some `Withdraw` entities did not have a `Finalized` event even if the withdrawal was finalized.