### PR TITLE
dApp: Hide `LandingPage`'s TVL `ProgressBar` component

### DIFF
--- a/dapp/src/pages/LandingPage/components/CurrentSeasonSection.tsx
+++ b/dapp/src/pages/LandingPage/components/CurrentSeasonSection.tsx
@@ -7,18 +7,18 @@ import {
   CardBody,
   Image,
 } from "@chakra-ui/react"
-import ProgressBar from "#/components/shared/ProgressBar"
-import { CurrencyBalance } from "#/components/shared/CurrencyBalance"
+// import ProgressBar from "#/components/shared/ProgressBar"
+// import { CurrencyBalance } from "#/components/shared/CurrencyBalance"
 import { H3, TextMd } from "#/components/shared/Typography"
-import { SEASON_CAP } from "#/constants"
+// import { SEASON_CAP } from "#/constants"
 import { LiveTag } from "#/components/shared/LiveTag"
 import { SeasonSectionBackground } from "#/components/shared/SeasonSectionBackground"
-import { useSeasonProgress } from "#/hooks"
+// import { useSeasonProgress } from "#/hooks"
 import { mezoLogoColor } from "#/assets/images/partner-logos"
 
 export default function CurrentSeasonSection() {
-  const { progress: seasonProgress, value: seasonTotalAssets } =
-    useSeasonProgress()
+  // const { progress: seasonProgress, value: seasonTotalAssets } =
+  //   useSeasonProgress()
 
   return (
     <Box position="relative" mb={5}>


### PR DESCRIPTION
Closes: https://github.com/thesis/acre/issues/682

Hid as requested.

### Context:
> [...] low/non existent TVL scaring depositors away, they think there is something wrong. Empty store phenomenon.

> We plan to reenable once we have >10 BTC in deposits.

<img width="839" alt="image" src="https://github.com/user-attachments/assets/c58d7a2e-4b0a-470d-965e-771bae5ee9e1">
