### PR TITLE
Add Blog link to season page and sidebar

### DIFF
--- a/dapp/src/components/Sidebar.tsx
+++ b/dapp/src/components/Sidebar.tsx
@@ -37,6 +37,12 @@ const BUTTONS: Partial<ComponentProps<typeof ButtonLink>>[] = [
     href: EXTERNAL_HREF.CONTRACTS,
     isExternal: true,
   },
+  {
+    children: "Blog",
+    colorScheme: "gold",
+    href: EXTERNAL_HREF.BLOG,
+    isExternal: true,
+  },
 ]
 
 const BENEFITS = [

--- a/dapp/src/constants/externalHref.ts
+++ b/dapp/src/constants/externalHref.ts
@@ -3,6 +3,7 @@ export const EXTERNAL_HREF = {
   DOCS: "https://docs.acre.fi",
   FAQ: "https://docs.acre.fi/faq",
   CONTRACTS: "https://docs.acre.fi/contracts",
+  BLOG: "https://blog.acre.fi",
   MEZO_INFO: "https://info.mezo.org",
   WEBSITE: "https://acre.fi",
   X: "https://x.com/AcreBTC",

--- a/dapp/src/pages/LandingPage/index.tsx
+++ b/dapp/src/pages/LandingPage/index.tsx
@@ -81,6 +81,10 @@ export default function LandingPage() {
           <CardButton href={EXTERNAL_HREF.FAQ} isExternal>
             FAQ
           </CardButton>
+
+          <CardButton href={EXTERNAL_HREF.BLOG} isExternal>
+            Blog
+          </CardButton>
         </VStack>
       </Flex>
     </>


### PR DESCRIPTION
We add a link to the blog on the season page and in the sidebar.

### Season Page
![image](https://github.com/user-attachments/assets/cc9b1368-8410-43bc-964e-2a8fdee85638)

### Sidebar
![image](https://github.com/user-attachments/assets/bee15fde-3b84-481f-bad8-2f7af5c106a3)
