### PR TITLE
MezoAllocator Withdrawals Improvements

### DIFF
--- a/solidity/contracts/MezoAllocator.sol
+++ b/solidity/contracts/MezoAllocator.sol
@@ -252,13 +252,13 @@ contract MezoAllocator is IDispatcher, Ownable2StepUpgradeable {
                     depositId,
                     uint96(amountToWithdraw)
                 );
-            } else if (amountToWithdraw > depositBalance) {
+            } else if (amountToWithdraw == depositBalance) {
+                mezoPortal.withdraw(address(tbtc), depositId);
+            } else {
                 revert WithdrawalAmountExceedsDepositBalance(
                     amountToWithdraw,
                     depositBalance
                 );
-            } else {
-                mezoPortal.withdraw(address(tbtc), depositId);
             }
 
             // slither-disable-next-line reentrancy-no-eth

--- a/solidity/contracts/MezoAllocator.sol
+++ b/solidity/contracts/MezoAllocator.sol
@@ -252,6 +252,7 @@ contract MezoAllocator is IDispatcher, Ownable2StepUpgradeable {
                     depositId,
                     uint96(amountToWithdraw)
                 );
+                // slither-disable-next-line incorrect-equality
             } else if (amountToWithdraw == depositBalance) {
                 mezoPortal.withdraw(address(tbtc), depositId);
             } else {

--- a/solidity/contracts/MezoAllocator.sol
+++ b/solidity/contracts/MezoAllocator.sol
@@ -142,6 +142,12 @@ contract MezoAllocator is IDispatcher, Ownable2StepUpgradeable {
     error MaintainerNotRegistered();
     /// @notice Reverts if the maintainer has been already registered.
     error MaintainerAlreadyRegistered();
+    /// @notice Reverts if the requested amount to withdraw exceeds the amount
+    ///         deposited in the Mezo Portal.
+    error WithdrawalAmountExceedsDepositBalance(
+        uint256 requestedAmount,
+        uint256 depositAmount
+    );
 
     modifier onlyMaintainer() {
         if (!isMaintainer[msg.sender]) {
@@ -232,6 +238,11 @@ contract MezoAllocator is IDispatcher, Ownable2StepUpgradeable {
                 address(tbtc),
                 depositId,
                 uint96(amount)
+            );
+        } else if (amount > depositBalance) {
+            revert WithdrawalAmountExceedsDepositBalance(
+                amount,
+                depositBalance
             );
         } else {
             mezoPortal.withdraw(address(tbtc), depositId);

--- a/solidity/contracts/MezoAllocator.sol
+++ b/solidity/contracts/MezoAllocator.sol
@@ -268,9 +268,12 @@ contract MezoAllocator is IDispatcher, Ownable2StepUpgradeable {
             .getDeposit(address(this), address(tbtc), depositId)
             .balance;
 
-        emit DepositReleased(depositId, amount);
-        depositBalance = 0;
-        mezoPortal.withdraw(address(tbtc), depositId);
+        if (amount > 0) {
+            emit DepositReleased(depositId, amount);
+            depositBalance = 0;
+            mezoPortal.withdraw(address(tbtc), depositId);
+        }
+
         tbtc.safeTransfer(address(stbtc), tbtc.balanceOf(address(this)));
     }
 

--- a/solidity/contracts/MezoAllocator.sol
+++ b/solidity/contracts/MezoAllocator.sol
@@ -127,7 +127,15 @@ contract MezoAllocator is IDispatcher, Ownable2StepUpgradeable {
         uint256 newDepositAmount
     );
     /// @notice Emitted when tBTC is withdrawn from MezoPortal.
-    event DepositWithdrawn(uint256 indexed depositId, uint256 amount);
+    /// If MezoAllocator has a positive balance part of the requested amount
+    /// is withdrawn from MezoAllocator and the rest from MezoPortal.
+    event WithdrawFromMezoPortal(
+        uint256 indexed depositId,
+        uint256 requestedAmount,
+        uint256 amountWithdrawnFromPortal
+    );
+    /// @notice Emitted when tBTC is withdrawn from MezoAllocator.
+    event WithdrawFromMezoAllocator(uint256 amount);
     /// @notice Emitted when the maintainer address is updated.
     event MaintainerAdded(address indexed maintainer);
     /// @notice Emitted when the maintainer address is updated.
@@ -236,7 +244,7 @@ contract MezoAllocator is IDispatcher, Ownable2StepUpgradeable {
         if (amount > unallocatedBalance) {
             uint256 amountToWithdraw = amount - unallocatedBalance;
 
-            emit DepositWithdrawn(depositId, amountToWithdraw);
+            emit WithdrawFromMezoPortal(depositId, amount, amountToWithdraw);
 
             if (amountToWithdraw < depositBalance) {
                 mezoPortal.withdrawPartially(
@@ -255,6 +263,8 @@ contract MezoAllocator is IDispatcher, Ownable2StepUpgradeable {
 
             // slither-disable-next-line reentrancy-no-eth
             depositBalance -= uint96(amountToWithdraw);
+        } else {
+            emit WithdrawFromMezoAllocator(amount);
         }
 
         tbtc.safeTransfer(address(stbtc), amount);

--- a/solidity/test/MezoAllocator.test.ts
+++ b/solidity/test/MezoAllocator.test.ts
@@ -341,11 +341,12 @@ describe("MezoAllocator", () => {
                 )
               })
 
-              it("should emit DepositWithdrawn event", async () => {
+              it("should emit WithdrawFromMezoPortal event", async () => {
                 await expect(tx)
-                  .to.emit(mezoAllocator, "DepositWithdrawn")
+                  .to.emit(mezoAllocator, "WithdrawFromMezoPortal")
                   .withArgs(
                     depositId,
+                    partialWithdrawal.requestedAmount,
                     partialWithdrawal.expectedWithdrawnAmount,
                   )
               })
@@ -394,10 +395,14 @@ describe("MezoAllocator", () => {
                 )
               })
 
-              it("should emit DepositWithdrawn event", async () => {
+              it("should emit WithdrawFromMezoPortal event", async () => {
                 await expect(tx)
-                  .to.emit(mezoAllocator, "DepositWithdrawn")
-                  .withArgs(depositId, fullWithdrawal.expectedWithdrawnAmount)
+                  .to.emit(mezoAllocator, "WithdrawFromMezoPortal")
+                  .withArgs(
+                    depositId,
+                    fullWithdrawal.requestedAmount,
+                    fullWithdrawal.expectedWithdrawnAmount,
+                  )
               })
 
               it("should decrease tracked deposit balance amount to zero", async () => {
@@ -499,8 +504,17 @@ describe("MezoAllocator", () => {
                 )
               })
 
-              it("should NOT emit DepositWithdrawn event", async () => {
-                await expect(tx).to.not.emit(mezoAllocator, "DepositWithdrawn")
+              it("should emit WithdrawFromMezoAllocator event", async () => {
+                await expect(tx)
+                  .to.emit(mezoAllocator, "WithdrawFromMezoAllocator")
+                  .withArgs(withdrawalAmount)
+              })
+
+              it("should NOT emit WithdrawFromMezoPortal event", async () => {
+                await expect(tx).to.not.emit(
+                  mezoAllocator,
+                  "WithdrawFromMezoPortal",
+                )
               })
 
               it("should NOT decrease tracked deposit balance amount", async () => {
@@ -535,8 +549,17 @@ describe("MezoAllocator", () => {
                 )
               })
 
-              it("should NOT emit DepositWithdrawn event", async () => {
-                await expect(tx).to.not.emit(mezoAllocator, "DepositWithdrawn")
+              it("should emit WithdrawFromMezoAllocator event", async () => {
+                await expect(tx)
+                  .to.emit(mezoAllocator, "WithdrawFromMezoAllocator")
+                  .withArgs(withdrawalAmount)
+              })
+
+              it("should NOT emit WithdrawFromMezoPortal event", async () => {
+                await expect(tx).to.not.emit(
+                  mezoAllocator,
+                  "WithdrawFromMezoPortal",
+                )
               })
 
               it("should NOT decrease tracked deposit balance amount", async () => {

--- a/solidity/test/MezoAllocator.test.ts
+++ b/solidity/test/MezoAllocator.test.ts
@@ -808,6 +808,7 @@ describe("MezoAllocator", () => {
       context("when there is a deposit", () => {
         beforeAfterSnapshotWrapper()
 
+        const depositId = 1
         const depositAmount = to1e18(5)
 
         before(async () => {

--- a/solidity/test/MezoAllocator.test.ts
+++ b/solidity/test/MezoAllocator.test.ts
@@ -94,6 +94,9 @@ describe("MezoAllocator", () => {
       context("when two consecutive deposits are made", () => {
         beforeAfterSnapshotWrapper()
 
+        const initialDepositId = 0
+        const expectedDepositId = 1
+
         context("when a first deposit is made", () => {
           let tx: ContractTransactionResponse
 
@@ -118,7 +121,7 @@ describe("MezoAllocator", () => {
 
           it("should increment the deposit id", async () => {
             const actualDepositId = await mezoAllocator.depositId()
-            expect(actualDepositId).to.equal(1)
+            expect(actualDepositId).to.equal(expectedDepositId)
           })
 
           it("should increase tracked deposit balance amount", async () => {
@@ -129,7 +132,12 @@ describe("MezoAllocator", () => {
           it("should emit DepositAllocated event", async () => {
             await expect(tx)
               .to.emit(mezoAllocator, "DepositAllocated")
-              .withArgs(0, 1, to1e18(6), to1e18(6))
+              .withArgs(
+                initialDepositId,
+                expectedDepositId,
+                to1e18(6),
+                to1e18(6),
+              )
           })
         })
 
@@ -144,13 +152,18 @@ describe("MezoAllocator", () => {
 
           it("should increment the deposit id", async () => {
             const actualDepositId = await mezoAllocator.depositId()
-            expect(actualDepositId).to.equal(2)
+            expect(actualDepositId).to.equal(expectedDepositId + 1)
           })
 
           it("should emit DepositAllocated event", async () => {
             await expect(tx)
               .to.emit(mezoAllocator, "DepositAllocated")
-              .withArgs(1, 2, to1e18(5), to1e18(11))
+              .withArgs(
+                expectedDepositId,
+                expectedDepositId + 1,
+                to1e18(5),
+                to1e18(11),
+              )
           })
 
           it("should deposit and transfer tBTC to Mezo Portal", async () => {
@@ -289,6 +302,8 @@ describe("MezoAllocator", () => {
       })
 
       context("when there is a deposit", () => {
+        const depositId = 1
+
         const testWithdrawalFromMezoPortal = ({
           initialDepositBalance,
           partialWithdrawal,
@@ -329,7 +344,10 @@ describe("MezoAllocator", () => {
               it("should emit DepositWithdrawn event", async () => {
                 await expect(tx)
                   .to.emit(mezoAllocator, "DepositWithdrawn")
-                  .withArgs(1, partialWithdrawal.expectedWithdrawnAmount)
+                  .withArgs(
+                    depositId,
+                    partialWithdrawal.expectedWithdrawnAmount,
+                  )
               })
 
               it("should decrease tracked deposit balance amount", async () => {
@@ -353,7 +371,7 @@ describe("MezoAllocator", () => {
                   .to.emit(mezoPortal, "WithdrawPartially")
                   .withArgs(
                     await tbtc.getAddress(),
-                    1,
+                    depositId,
                     partialWithdrawal.expectedWithdrawnAmount,
                   )
               })
@@ -379,7 +397,7 @@ describe("MezoAllocator", () => {
               it("should emit DepositWithdrawn event", async () => {
                 await expect(tx)
                   .to.emit(mezoAllocator, "DepositWithdrawn")
-                  .withArgs(1, fullWithdrawal.expectedWithdrawnAmount)
+                  .withArgs(depositId, fullWithdrawal.expectedWithdrawnAmount)
               })
 
               it("should decrease tracked deposit balance amount to zero", async () => {
@@ -398,7 +416,7 @@ describe("MezoAllocator", () => {
               it("should call MezoPortal.withdraw function", async () => {
                 await expect(tx)
                   .to.emit(mezoPortal, "WithdrawFully")
-                  .withArgs(await tbtc.getAddress(), 1)
+                  .withArgs(await tbtc.getAddress(), depositId)
               })
             })
 
@@ -809,7 +827,7 @@ describe("MezoAllocator", () => {
           it("should emit DepositReleased event", async () => {
             await expect(tx)
               .to.emit(mezoAllocator, "DepositReleased")
-              .withArgs(1, depositAmount)
+              .withArgs(depositId, depositAmount)
           })
 
           it("should decrease tracked deposit balance amount to zero", async () => {
@@ -828,7 +846,7 @@ describe("MezoAllocator", () => {
           it("should call MezoPortal.withdraw function", async () => {
             await expect(tx)
               .to.emit(mezoPortal, "WithdrawFully")
-              .withArgs(await tbtc.getAddress(), 1)
+              .withArgs(await tbtc.getAddress(), depositId)
           })
         })
 
@@ -848,7 +866,7 @@ describe("MezoAllocator", () => {
           it("should emit DepositReleased event", async () => {
             await expect(tx)
               .to.emit(mezoAllocator, "DepositReleased")
-              .withArgs(1, depositAmount)
+              .withArgs(depositId, depositAmount)
           })
 
           it("should decrease tracked deposit balance amount to zero", async () => {
@@ -867,7 +885,7 @@ describe("MezoAllocator", () => {
           it("should call MezoPortal.withdraw function", async () => {
             await expect(tx)
               .to.emit(mezoPortal, "WithdrawFully")
-              .withArgs(await tbtc.getAddress(), 1)
+              .withArgs(await tbtc.getAddress(), depositId)
           })
         })
       })


### PR DESCRIPTION
Depends on: https://github.com/thesis/acre/pull/716

In this PR we introduce a couple of improvements to the MezoAllocator contract related to withdrawals from the Mezo Portal.

### Check if the withdrawal amount exceeds the deposit balance (1b95419737ea5d012647e0558e61a11b08feec86)

Here we improve the withdrawal function to check if the withdrawal amount exceeds the deposit balance.
If the withdrawal amount exceeds the deposit balance, the function will revert with a custom error message.
Before these changes, since the Portal contract changed the handling of partial and full withdrawals the withdrawal function reverted on `depositBalance -= uint96(amount);` with:
```
panic code 0x11 (Arithmetic operation overflowed outside of an unchecked block)
```

### Include unallocated MezoAllocator balance in `withdraw` and `releaseDeposit` (1b9ba17fe3df251445dc36b6b6452c3dd242ccb0, 0440580dcfcc879eb417d07033c30ed33af3e3a2)

In bb42bce291dc77a64d77a6500492ef23714aeb03 we included the current balance of the MezoAllocator contract in the `totalAssets` function result. The balance can come from a rewards transfer or any donation.

We haven't considered this balance in the `withdraw` function, which could lead to blocking the last user withdrawing the funds, as the balance of assets owned by them calculated based on `totalAssets` function, couldn't be fully withdraw due to unallocated balance being stuck in the `MezoAllocator` contract. In 1b9ba17fe3df251445dc36b6b6452c3dd242ccb0 we introduce possibility to withdraw funds from the unallocated contract balance.

For the `releaseDeposit` function we could face a problem when the Mezo Portal deposit is already released but some tokens were donated to the MezoAllocator contract, since the `Porta.withdraw` function would be reverting as there is no deposit, we won't be able to transfer the unallocated funds in the same call. We fixed it in 0440580dcfcc879eb417d07033c30ed33af3e3a2.

> [!IMPORTANT]  
> Please ignore failing integration tests, as these will be fixed in https://github.com/thesis/acre/pull/718