### PR TITLE
Improvements to the mintDebt and repayDebt functions in stBTC contract

### DIFF
--- a/solidity/contracts/stBTC.sol
+++ b/solidity/contracts/stBTC.sol
@@ -326,8 +326,6 @@ contract stBTC is ERC4626Fees, PausableOwnable {
 
         // Mint the shares to the receiver.
         super._mint(receiver, shares);
-
-        return shares;
     }
 
     /// @dev This function proxies `mintDebt` call and provides compatibility
@@ -368,8 +366,6 @@ contract stBTC is ERC4626Fees, PausableOwnable {
 
         // Burn the shares from the debtor.
         super._burn(msg.sender, shares);
-
-        return shares;
     }
 
     /// @notice This function proxies `repayDebt` call and provides

--- a/solidity/contracts/test/stBTCStub.sol
+++ b/solidity/contracts/test/stBTCStub.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "../stBTC.sol";
+
+contract stBTCStub is stBTC {
+    using SafeERC20 for IERC20;
+
+    function workaround_transfer(address to, uint256 amount) external {
+        IERC20(asset()).safeTransfer(to, amount);
+    }
+}

--- a/solidity/deploy/01_deploy_stbtc.ts
+++ b/solidity/deploy/01_deploy_stbtc.ts
@@ -10,7 +10,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const tbtc = await deployments.get("TBTC")
 
   const [, stbtcDeployment] = await helpers.upgrades.deployProxy("stBTC", {
-    contractName: "stBTC",
+    contractName: hre.network.name === "hardhat" ? "stBTCStub" : "stBTC",
     initializerArgs: [tbtc.address, treasury],
     factoryOpts: {
       signer: deployerSigner,

--- a/solidity/test/stBTC.test.ts
+++ b/solidity/test/stBTC.test.ts
@@ -3287,6 +3287,10 @@ describe("stBTC", () => {
                 newShares,
               )
           })
+
+          it("should return the expected debt in assets", () => {
+            expect(mintDebtResult).to.be.eq(expectedNewDebt)
+          })
         })
       }
     })
@@ -3496,6 +3500,8 @@ describe("stBTC", () => {
               let initialTotalDebt: bigint
               let initialTotalSupply: bigint
               let initialTotalAssets: bigint
+
+              let repayDebtResult: bigint
               let tx: ContractTransactionResponse
 
               before(async () => {
@@ -3506,6 +3512,9 @@ describe("stBTC", () => {
                 initialTotalSupply = await stbtc.totalSupply()
                 initialTotalAssets = await stbtc.totalAssets()
 
+                repayDebtResult = await stbtc
+                  .connect(externalMinter)
+                  .repayDebt.staticCall(repaySharesAmount)
                 tx = await stbtc
                   .connect(externalMinter)
                   .repayDebt(repaySharesAmount)
@@ -3552,6 +3561,10 @@ describe("stBTC", () => {
                     expectedDebtRepayment,
                     repaySharesAmount,
                   )
+              })
+
+              it("should return the expected debt in assets", () => {
+                expect(repayDebtResult).to.be.eq(expectedDebtRepayment)
               })
             }
           })


### PR DESCRIPTION
### Fix returns in mintDebt and repayDebt functions (4f67f035076dd6dd37461d14a0fd771bbf9645f1)

The `mintDebt` and `repayDebt` functions are expected to return the amount of assets calculated based on the provided amount of shares:
```solidity
) public whenNotPaused returns (uint256 assets) {
```
but they were returning the amount of shares instead:
```solidity
return shares;
```
We fix this problem and add tests to cover these cases.

### Fix rounding of shares to assets conversions in debt minting (490b1790154e8c7842541f08ea9b1a11097e2437)

Previously, the shares-to-assets conversion was rounding down, which could have resulted in the minted debt being against the vault's interest.

Suppose a scenario where the vault has a 10% loss, meaning that each share is worth 0.9 assets.
If a user mints 1 share, the debt registered due to rounding down would be 0.
This can be used in a griefing attack, where a user could mint shares without registering debt.

To fix the issue, we now round up the shares to assets conversion in the `mintDebt` function.

Additionally, for the `repayDebt` function, we keep rounding down the shares to assets to avoid the opposite issue, where a user could repay more debt than they should.

It may happen that conversion in `repayDebt` returns `0`, which should be validated by the caller. Since the interface used by the Mezo Portal contract `burnReceipt` function doesn't consider the return value of `repayDebt`, we are performing the validation in the `burnReceipt` function. We added a similar validation in the `mintReceipt` function for consistency.