### PR TITLE
Bump orangekit packages to `1.0.0-beta.31`

### DIFF
--- a/dapp/package.json
+++ b/dapp/package.json
@@ -20,7 +20,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@orangekit/react": "1.0.0-beta.30",
+    "@orangekit/react": "1.0.0-beta.31",
     "@orangekit/sign-in-with-wallet": "1.0.0-beta.6",
     "@reduxjs/toolkit": "^2.2.0",
     "@rehooks/local-storage": "^2.4.5",

--- a/dapp/package.json
+++ b/dapp/package.json
@@ -20,7 +20,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@orangekit/react": "1.0.0-beta.31",
+    "@orangekit/react": "1.0.0-beta.32",
     "@orangekit/sign-in-with-wallet": "1.0.0-beta.6",
     "@reduxjs/toolkit": "^2.2.0",
     "@rehooks/local-storage": "^2.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^11.11.0
         version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
       '@orangekit/react':
-        specifier: 1.0.0-beta.31
-        version: 1.0.0-beta.31(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(typescript@5.4.5)
+        specifier: 1.0.0-beta.32
+        version: 1.0.0-beta.32(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(typescript@5.4.5)
       '@orangekit/sign-in-with-wallet':
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(bech32@2.0.0)(ethers@6.13.0)
@@ -5751,10 +5751,10 @@ packages:
       - ethers
     dev: false
 
-  /@orangekit/react@1.0.0-beta.31(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(typescript@5.4.5):
-    resolution: {integrity: sha512-J/lQJBj/r3Vvkx1+RE3HF17Soou23nKDQH2kEb+DQAXVrSWDI2fv7WIEyR+qfNWaoRQgS980iJgnPO5Ak0NFBA==}
+  /@orangekit/react@1.0.0-beta.32(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(typescript@5.4.5):
+    resolution: {integrity: sha512-/ztJG0QjGoRDhs7sBCFxsAeTs5eVnm6e5qFKlDTwSbTP5AIQRTdjlQL+ThuTPjeZJBtyCTC+OvEFvt3PfVXEog==}
     dependencies:
-      '@orangekit/sdk': 1.0.0-beta.16
+      '@orangekit/sdk': 1.0.0-beta.17
       '@rainbow-me/rainbowkit': 2.0.2(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)(viem@2.8.16)(wagmi@2.5.12)
       ethers: 6.12.1
       react: 18.3.1
@@ -5794,6 +5794,24 @@ packages:
 
   /@orangekit/sdk@1.0.0-beta.16:
     resolution: {integrity: sha512-0tU/p9iRw3JDbJjvWLjrbyqLEKBUUUX/q6ccNw9MtIPiHGVvr0wnaZvgs7c1shGJGIREhNMBRbwgS9782Yr/SQ==}
+    dependencies:
+      '@gelatonetwork/relay-sdk': 5.5.6
+      '@noble/curves': 1.4.0
+      '@noble/hashes': 1.4.0
+      '@orangekit/contracts': 1.0.0-beta.3(ethers@6.12.1)
+      '@safe-global/protocol-kit': 3.1.1
+      bitcoinjs-lib: 6.1.5
+      ethers: 6.12.1
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /@orangekit/sdk@1.0.0-beta.17:
+    resolution: {integrity: sha512-SWGWbsidxe9qRGTzRcvVxNVC//HBEj7L0QIqduFAu2RVe1Khi4HlS1jEkfcvLTxwjY0qzDQwUyxWovSmnJKZNw==}
     dependencies:
       '@gelatonetwork/relay-sdk': 5.5.6
       '@noble/curves': 1.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^11.11.0
         version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
       '@orangekit/react':
-        specifier: 1.0.0-beta.30
-        version: 1.0.0-beta.30(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(typescript@5.4.5)(valibot@0.33.2)
+        specifier: 1.0.0-beta.31
+        version: 1.0.0-beta.31(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(typescript@5.4.5)
       '@orangekit/sign-in-with-wallet':
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(bech32@2.0.0)(ethers@6.13.0)
@@ -5751,14 +5751,14 @@ packages:
       - ethers
     dev: false
 
-  /@orangekit/react@1.0.0-beta.30(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(typescript@5.4.5)(valibot@0.33.2):
-    resolution: {integrity: sha512-hH5rRTDy0rDuVvgZKb53/fiQHHMjUlOL0pufMbv4fuy0AzrnNHu4ohFEJCyANpiL/FppdBZiFa/paqv+9obotg==}
+  /@orangekit/react@1.0.0-beta.31(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(typescript@5.4.5):
+    resolution: {integrity: sha512-J/lQJBj/r3Vvkx1+RE3HF17Soou23nKDQH2kEb+DQAXVrSWDI2fv7WIEyR+qfNWaoRQgS980iJgnPO5Ak0NFBA==}
     dependencies:
       '@orangekit/sdk': 1.0.0-beta.16
       '@rainbow-me/rainbowkit': 2.0.2(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)(viem@2.8.16)(wagmi@2.5.12)
       ethers: 6.12.1
       react: 18.3.1
-      sats-connect: 2.5.0(typescript@5.4.5)(valibot@0.33.2)
+      sats-connect: 2.8.0(typescript@5.4.5)
       viem: 2.8.16(typescript@5.4.5)
       wagmi: 2.5.12(@tanstack/react-query@5.45.0)(@types/react@18.3.3)(react-dom@18.3.1)(react-native@0.74.2)(react@18.3.1)(typescript@5.4.5)(viem@2.8.16)
     transitivePeerDependencies:
@@ -5789,7 +5789,6 @@ packages:
       - typescript
       - uWebSockets.js
       - utf-8-validate
-      - valibot
       - zod
     dev: false
 
@@ -6784,12 +6783,10 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@sats-connect/core@0.0.15(valibot@0.33.2):
-    resolution: {integrity: sha512-f+s+uM4BnjLs+I8AHp4Tf4GG8kMLGn44RalNZqlo/OkTeZj+llQEsMEwfKkIM8f45gA3jSWqmn4q/LsjMpWlVw==}
-    peerDependencies:
-      valibot: 0.33.2
+  /@sats-connect/core@0.2.2:
+    resolution: {integrity: sha512-nl3zPnV1UBllYAniDfhM/oSFGQ2qy4cCg1YwxJZ+RQMwlTMrVh2f3lJ//dIIo9RgQPrtHpwrAaaWW0VpfqDQbg==}
     dependencies:
-      axios: 1.6.8
+      axios: 1.7.4
       bitcoin-address-validation: 2.2.3
       buffer: 6.0.3
       jsontokens: 4.0.1
@@ -6799,13 +6796,13 @@ packages:
       - debug
     dev: false
 
-  /@sats-connect/make-default-provider-config@0.0.5(@sats-connect/core@0.0.15)(typescript@5.4.5):
+  /@sats-connect/make-default-provider-config@0.0.5(@sats-connect/core@0.2.2)(typescript@5.4.5):
     resolution: {integrity: sha512-b/v4IeDEde5DqFOdMbMmf3B0t/lxlKnY04f3YIUWe1khOg3S6VdcK9Mqva+WUOsJHBTIA5b4hK7CqfMjx1Ic+w==}
     peerDependencies:
       '@sats-connect/core': '*'
       typescript: 5.4.4
     dependencies:
-      '@sats-connect/core': 0.0.15(valibot@0.33.2)
+      '@sats-connect/core': 0.2.2
       '@sats-connect/ui': 0.0.6
       bowser: 2.11.0
       typescript: 5.4.5
@@ -9420,16 +9417,6 @@ packages:
       - debug
     dev: false
 
-  /axios@1.6.8:
-    resolution: {integrity: sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==}
-    dependencies:
-      follow-redirects: 1.15.6(debug@4.3.4)
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /axios@1.7.2:
     resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
     dependencies:
@@ -9449,6 +9436,16 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
+
+  /axios@1.7.4:
+    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
+    dependencies:
+      follow-redirects: 1.15.6(debug@4.3.4)
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
@@ -18762,16 +18759,15 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sats-connect@2.5.0(typescript@5.4.5)(valibot@0.33.2):
-    resolution: {integrity: sha512-oyKQMH07dvXv/UCUlbHWoLsfycnDgsyipyaUovnFBsG85t1jF6wlXcGDPwiD8fIUmplDD6UmHlyAfCL8ai5b3w==}
+  /sats-connect@2.8.0(typescript@5.4.5):
+    resolution: {integrity: sha512-eYdpPoAXn6ud1hMZnQGowO1F0f9fS3jmE5Hq1F3VxXUbAvT2YmA72PBtG6QN/cdMuFZ5x1ce6I/fl270WSXqjw==}
     dependencies:
-      '@sats-connect/core': 0.0.15(valibot@0.33.2)
-      '@sats-connect/make-default-provider-config': 0.0.5(@sats-connect/core@0.0.15)(typescript@5.4.5)
+      '@sats-connect/core': 0.2.2
+      '@sats-connect/make-default-provider-config': 0.0.5(@sats-connect/core@0.2.2)(typescript@5.4.5)
       '@sats-connect/ui': 0.0.6
     transitivePeerDependencies:
       - debug
       - typescript
-      - valibot
     dev: false
 
   /sc-istanbul@0.4.6:


### PR DESCRIPTION
This PR updates the package for `orangeKit/react` to `1.0.0-beta.31`. What's Changed: 

- Ledger accounts support by Xverse
- Reduce the modals displayed to one for Xverse (connection action). Note that only one modal is displayed for Connect wallet modal (+ one additional one for Sign message) so we for the full connecting + signing process we only need 2 modals now instead of 3 for Xverse.

Note that you should use the latest version of the Xverse wallet.