### PR TITLE
Fix wallets integration issues

### DIFF
--- a/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
+++ b/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
@@ -62,14 +62,14 @@ export default function ConnectWalletButton({
   } = useWallet()
   const { signMessageStatus, resetMessageStatus, signMessageAndCreateSession } =
     useSignMessageAndCreateSession()
-  const { setConnectionError, resetConnectionError } =
+  const { connectionError, setConnectionError, resetConnectionError } =
     useWalletConnectionError()
   const { closeModal } = useModal()
   const dispatch = useAppDispatch()
 
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
-  const hasConnectionError = connectionStatus === "error"
+  const hasConnectionError = connectionError || connectionStatus === "error"
   const hasSignMessageStatus = signMessageStatus === "error"
   const showStatuses = isSelected && !hasConnectionError
   const showRetryButton = address && hasSignMessageStatus
@@ -92,11 +92,17 @@ export default function ConnectWalletButton({
       } catch (error) {
         if (eip1193.didUserRejectRequest(error)) return
 
+        onDisconnect()
         console.error("Failed to sign siww message", error)
         setConnectionError(CONNECTION_ERRORS.INVALID_SIWW_SIGNATURE)
       }
     },
-    [signMessageAndCreateSession, onSuccessSignMessage, setConnectionError],
+    [
+      signMessageAndCreateSession,
+      onSuccessSignMessage,
+      onDisconnect,
+      setConnectionError,
+    ],
   )
 
   const onSuccessConnection = useCallback(

--- a/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
+++ b/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
@@ -60,7 +60,7 @@ export default function ConnectWalletButton({
     onDisconnect,
     status: connectionStatus,
   } = useWallet()
-  const { signMessageStatus, signMessageAndCreateSession } =
+  const { signMessageStatus, resetMessageStatus, signMessageAndCreateSession } =
     useSignMessageAndCreateSession()
   const { setConnectionError } = useWalletConnectionError()
   const { closeModal } = useModal()
@@ -137,6 +137,8 @@ export default function ConnectWalletButton({
 
   const handleButtonClick = () => {
     onDisconnect()
+    onClick()
+    resetMessageStatus()
 
     const isInstalled = orangeKit.isWalletInstalled(connector)
 
@@ -146,7 +148,6 @@ export default function ConnectWalletButton({
     }
 
     handleConnection()
-    onClick()
   }
 
   return (

--- a/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
+++ b/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
@@ -62,7 +62,8 @@ export default function ConnectWalletButton({
   } = useWallet()
   const { signMessageStatus, resetMessageStatus, signMessageAndCreateSession } =
     useSignMessageAndCreateSession()
-  const { setConnectionError } = useWalletConnectionError()
+  const { setConnectionError, resetConnectionError } =
+    useWalletConnectionError()
   const { closeModal } = useModal()
   const dispatch = useAppDispatch()
 
@@ -136,8 +137,11 @@ export default function ConnectWalletButton({
   }, [connector])
 
   const handleButtonClick = () => {
+    // Do not trigger action again when wallet connection is in progress
+    if (showStatuses) return
+
     onDisconnect()
-    onClick()
+    resetConnectionError()
     resetMessageStatus()
 
     const isInstalled = orangeKit.isWalletInstalled(connector)
@@ -147,6 +151,7 @@ export default function ConnectWalletButton({
       return
     }
 
+    onClick()
     handleConnection()
   }
 

--- a/dapp/src/components/ConnectWalletModal/index.tsx
+++ b/dapp/src/components/ConnectWalletModal/index.tsx
@@ -23,7 +23,6 @@ export function ConnectWalletModalBase({
   const { connectionError, resetConnectionError } = useWalletConnectionError()
 
   const handleButtonOnClick = (connector: OrangeKitConnector) => {
-    resetConnectionError()
     setSelectedConnectorId(connector.id)
   }
 

--- a/dapp/src/hooks/useSignMessageAndCreateSession.ts
+++ b/dapp/src/hooks/useSignMessageAndCreateSession.ts
@@ -4,7 +4,11 @@ import { useCallback } from "react"
 import { useSignMessage } from "wagmi"
 
 function useSignMessageAndCreateSession() {
-  const { signMessageAsync, status: signMessageStatus } = useSignMessage()
+  const {
+    signMessageAsync,
+    status: signMessageStatus,
+    reset: resetMessageStatus,
+  } = useSignMessage()
 
   const signMessageAndCreateSession = useCallback(
     async (connectedConnector: OrangeKitConnector, btcAddress: string) => {
@@ -50,8 +54,9 @@ function useSignMessageAndCreateSession() {
   )
 
   return {
-    signMessageAndCreateSession,
     signMessageStatus,
+    resetMessageStatus,
+    signMessageAndCreateSession,
   }
 }
 export default useSignMessageAndCreateSession


### PR DESCRIPTION
Ref https://github.com/thesis/acre/issues/726
Closes https://github.com/thesis/acre/issues/732

This PR improves dApp integration with browser wallets. After rejecting any of the actions during account connection, the dApp opened uncontrollable wallet windows. What has been done:

- The changes trigger an action when the button is clicked. Additionally, when the user rejects signing the message a special button is shown to repeat the action.
- Do not trigger connection action again when wallet is selected.
- Reset the status of the sign message to the initial state when the user changed the wallet and back to the previous one.

Specific issues for the Unisat wallet will be resolved in the next PR.

### UI

#### Before

**Rejecting the action - Connect wallet**

https://github.com/user-attachments/assets/756addd4-092a-4ff3-a3f7-09e2812ce893


**Rejecting the action - Sign message**
https://github.com/user-attachments/assets/64a1039a-35c5-46fd-b384-0d57a37e2fd0




#### After

**Rejecting the action - Connect wallet**
https://github.com/user-attachments/assets/4fad2923-6a18-43f9-ad14-69dcd46bf9b2

**Rejecting the action - Sign message**

https://github.com/user-attachments/assets/d46d448e-e94d-434c-8f47-23278d149a85

