### PR TITLE
Register logged in user Bitcoin address when registering a deposit

### DIFF
--- a/sdk/src/lib/api/TbtcApi.ts
+++ b/sdk/src/lib/api/TbtcApi.ts
@@ -113,6 +113,7 @@ export type SaveRevealRequest = {
   revealInfo: BitcoinDepositReceiptJson
   metadata: RevealMetadata
   application: string
+  loggedInUser?: string
 }
 
 // TODO: This type is copied from tbtc-api, we should consider exporting it from there.

--- a/sdk/src/modules/account.ts
+++ b/sdk/src/modules/account.ts
@@ -122,6 +122,7 @@ export default class Account {
       this.#ethereumAddress,
       finalBitcoinRecoveryAddress,
       referral,
+      this.#bitcoinAddress,
     )
 
     return new StakeInitialization(tbtcDeposit)

--- a/sdk/src/modules/tbtc/Tbtc.ts
+++ b/sdk/src/modules/tbtc/Tbtc.ts
@@ -76,11 +76,13 @@ export default class Tbtc {
    * @param bitcoinRecoveryAddress P2PKH or P2WPKH Bitcoin address that can be
    *        used for emergency recovery of the deposited funds.
    * @param referral Deposit referral number.
+   * @param loggedInUser Identifier of the user who initiated the deposit.
    */
   async initiateDeposit(
     depositOwner: ChainIdentifier,
     bitcoinRecoveryAddress: string,
     referral: number,
+    loggedInUser: string,
   ): Promise<Deposit> {
     if (!depositOwner || !bitcoinRecoveryAddress) {
       throw new Error("Ethereum or Bitcoin address is not available")
@@ -114,6 +116,7 @@ export default class Tbtc {
         referral,
       },
       application: "acre",
+      loggedInUser,
     }
 
     const revealSaved: boolean = await this.#tbtcApi.saveReveal(revealData)

--- a/sdk/test/data/deposit.ts
+++ b/sdk/test/data/deposit.ts
@@ -12,6 +12,7 @@ const depositTestData: {
   bitcoinRecoveryAddress: string
   referral: number
   extraData: Hex
+  loggedInUser: string
 } = {
   depositOwner: EthereumAddress.from(
     "0xa9B38eA6435c8941d6eDa6a46b68E3e211719699",
@@ -21,6 +22,7 @@ const depositTestData: {
   extraData: Hex.from(
     "0xa9b38ea6435c8941d6eda6a46b68e3e2117196995bd100000000000000000000",
   ),
+  loggedInUser: "bc1qyulqtdwqkx055hje0sft59hhd7xqurnquhaghe",
 }
 
 const receiptTestData: DepositReceipt = {
@@ -47,6 +49,7 @@ const revealTestData: SaveRevealRequest = {
     referral: depositTestData.referral,
   },
   application: "acre",
+  loggedInUser: depositTestData.loggedInUser,
 }
 
 const fundingUtxo: {

--- a/sdk/test/modules/account.test.ts
+++ b/sdk/test/modules/account.test.ts
@@ -150,6 +150,7 @@ describe("Account", () => {
             predictedEthereumDepositorAddress,
             bitcoinRecoveryAddress,
             referral,
+            bitcoinDepositorAddress,
           )
         })
 

--- a/sdk/test/modules/tbtc/Tbtc.test.ts
+++ b/sdk/test/modules/tbtc/Tbtc.test.ts
@@ -110,6 +110,7 @@ describe("Tbtc", () => {
             depositTestData.depositOwner,
             emptyBitcoinRecoveryAddress,
             depositTestData.referral,
+            depositTestData.loggedInUser,
           ),
         ).rejects.toThrow("Ethereum or Bitcoin address is not available")
       })
@@ -141,6 +142,7 @@ describe("Tbtc", () => {
             depositTestData.depositOwner,
             depositTestData.bitcoinRecoveryAddress,
             depositTestData.referral,
+            depositTestData.loggedInUser,
           )
         })
 
@@ -164,6 +166,7 @@ describe("Tbtc", () => {
               depositTestData.depositOwner,
               depositTestData.bitcoinRecoveryAddress,
               depositTestData.referral,
+              depositTestData.loggedInUser,
             ),
           ).rejects.toThrow("Reveal not saved properly in the database")
         })


### PR DESCRIPTION
Depends on: https://github.com/thesis/acre-bots/pull/42
Closes: https://github.com/thesis/acre/issues/502

We want to track the Bitcoin address of the logged in user, so we can easily query the reveals table for the user's reveals.