### PR TITLE
dApp: Calculate points when min amount met

### DIFF
--- a/dapp/src/components/TransactionModal/ActiveStakingStep/StakeFormModal/AcrePointsRewardEstimation.tsx
+++ b/dapp/src/components/TransactionModal/ActiveStakingStep/StakeFormModal/AcrePointsRewardEstimation.tsx
@@ -13,7 +13,7 @@ import { H4, TextMd } from "#/components/shared/Typography"
 import { numberToLocaleString } from "#/utils"
 import { IconChevronDown } from "@tabler/icons-react"
 import { TOKEN_AMOUNT_FIELD_NAME } from "#/components/shared/TokenAmountForm/TokenAmountFormBase"
-import { useFormField } from "#/hooks"
+import { useFormField, useMinDepositAmount } from "#/hooks"
 import { ONE_MONTH_IN_DAYS, ONE_WEEK_IN_DAYS } from "#/constants"
 
 const ACRE_POINTS_DATA = {
@@ -48,7 +48,10 @@ function AcrePointsRewardEstimation(props: StackProps) {
   const { value = 0n } = useFormField<bigint | undefined>(
     TOKEN_AMOUNT_FIELD_NAME,
   )
-  const baseReward = Number(value)
+  const minDepositAmount = useMinDepositAmount()
+  const amount = value >= minDepositAmount ? value : 0n
+
+  const baseReward = Number(amount)
   const pointsRate = 10000
 
   const estimatedReward = useMemo(


### PR DESCRIPTION
Closes: #829 

This pull request includes changes to the `AcrePointsRewardEstimation` component to improve the calculation of rewards based on a minimum deposit amount.

* [`dapp/src/components/TransactionModal/ActiveStakingStep/StakeFormModal/AcrePointsRewardEstimation.tsx`](diffhunk://#diff-338bb32cc5e0756bafcfaf57b8823a7cad2e51460efcee50ef3d21d3eb59a92eL16-R16): Imported `useMinDepositAmount` hook to determine the minimum deposit amount for reward calculation.
* [`dapp/src/components/TransactionModal/ActiveStakingStep/StakeFormModal/AcrePointsRewardEstimation.tsx`](diffhunk://#diff-338bb32cc5e0756bafcfaf57b8823a7cad2e51460efcee50ef3d21d3eb59a92eL51-R54): Updated the `AcrePointsRewardEstimation` component by adjustment of reward calculation logic to ensure the value meets the minimum deposit amount.