### PR TITLE
dApp: Implement total Acre Points pool balance

### DIFF
--- a/dapp/src/hooks/useAcrePoints.ts
+++ b/dapp/src/hooks/useAcrePoints.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { acreApi } from "#/utils"
-import { queryKeysFactory } from "#/constants"
+import { queryKeysFactory, REFETCH_INTERVAL_IN_MILLISECONDS } from "#/constants"
 import { MODAL_TYPES } from "#/types"
 import { useWallet } from "./useWallet"
 import { useModal } from "./useModal"
@@ -15,6 +15,7 @@ type UseAcrePointsReturnType = {
   claimPoints: () => void
   updateUserPointsData: () => Promise<unknown>
   updatePointsData: () => Promise<unknown>
+  totalPoolBalance: number
 }
 
 export default function useAcrePoints(): UseAcrePointsReturnType {
@@ -30,6 +31,7 @@ export default function useAcrePoints(): UseAcrePointsReturnType {
   const pointsDataQuery = useQuery({
     queryKey: [...acreKeys.pointsData()],
     queryFn: async () => acreApi.getPointsData(),
+    refetchInterval: REFETCH_INTERVAL_IN_MILLISECONDS,
   })
 
   const { mutate: claimPoints } = useMutation({
@@ -58,5 +60,6 @@ export default function useAcrePoints(): UseAcrePointsReturnType {
     claimPoints,
     updateUserPointsData: userPointsDataQuery.refetch,
     updatePointsData: pointsDataQuery.refetch,
+    totalPoolBalance: pointsDataQuery.data?.totalPool ?? 0,
   }
 }

--- a/dapp/src/pages/DashboardPage/AcrePointsCard.tsx
+++ b/dapp/src/pages/DashboardPage/AcrePointsCard.tsx
@@ -30,6 +30,7 @@ export default function AcrePointsCard(props: CardProps) {
     updateUserPointsData,
     updatePointsData,
     isCalculationInProgress,
+    totalPoolBalance,
   } = useAcrePoints()
   const { isConnected } = useWallet()
 
@@ -37,6 +38,7 @@ export default function AcrePointsCard(props: CardProps) {
 
   const formattedTotalPointsAmount = numberToLocaleString(totalBalance)
   const formattedClaimablePointsAmount = numberToLocaleString(claimableBalance)
+  const formattedTotalPoolBalance = numberToLocaleString(totalPoolBalance)
 
   const handleOnCountdownEnd = () => {
     logPromiseFailure(updatePointsData())
@@ -50,21 +52,27 @@ export default function AcrePointsCard(props: CardProps) {
     <Card px={4} py={5} {...props}>
       <CardHeader p={0} mb={2} as={HStack} justify="space-between">
         <TextMd fontWeight="bold" color="grey.700">
-          Total Acre points
+          {isConnected ? "Your" : "Total"} Acre points
         </TextMd>
 
-        {isConnected && (
-          <InfoTooltip
-            // TODO: Add alternative variant of label for disconnected wallet
-            label="Your current balance of Acre points collected so far. New points drop daily and are ready to be claimed. Unclaimed points roll over to the next day."
-            w={56}
-          />
-        )}
+        <InfoTooltip
+          label={
+            isConnected
+              ? "Your current balance of Acre points collected so far. New points drop daily and are ready to be claimed. Unclaimed points roll over to the next day."
+              : "Total points distributed to Acre users so far. New points drop daily and can be claimed in each user's dashboard."
+          }
+          w={56}
+        />
       </CardHeader>
 
       <CardBody p={0}>
         <UserDataSkeleton>
-          <H4 mb={2}>{formattedTotalPointsAmount}&nbsp;PTS</H4>
+          <H4 mb={2}>
+            {isConnected
+              ? formattedTotalPointsAmount
+              : formattedTotalPoolBalance}
+            &nbsp;PTS
+          </H4>
 
           {isDataReady && (
             <VStack px={4} py={3} spacing={0} rounded="lg" bg="gold.100">

--- a/dapp/src/utils/acreApi.ts
+++ b/dapp/src/utils/acreApi.ts
@@ -37,6 +37,7 @@ async function deleteSession() {
 type PointsDataResponse = {
   dropAt: number
   isCalculationInProgress: boolean
+  totalPool: string
 }
 
 const getPointsData = async () => {
@@ -46,6 +47,7 @@ const getPointsData = async () => {
   return {
     dropAt: response.data.dropAt,
     isCalculationInProgress: response.data.isCalculationInProgress,
+    totalPool: Number(response.data.totalPool),
   }
 }
 


### PR DESCRIPTION
Closes: #804 
Ref: https://github.com/thesis/acre-bots/pull/51

This pull request introduces several enhancements to the Acre Points feature, including the addition of a total pool balance, periodic data refetching, and improved user interface elements.

Enhancements to Acre Points feature:

* [`dapp/src/hooks/useAcrePoints.ts`](diffhunk://#diff-50509a2a9c5c760f8862e203441b351818ef1a74dcda1d67bd182dc28b8abafeL3-R3): Added `totalPoolBalance` to the return type of `useAcrePoints` and included a periodic data refetch interval using `REFETCH_INTERVAL_IN_MILLISECONDS`. 
* [`dapp/src/pages/DashboardPage/AcrePointsCard.tsx`](diffhunk://#diff-fa83f2c138fd549157e83bc1a2f0febde516a577e3ac3d3a4680ac1084ae7acdR33-R41): Updated `AcrePointsCard` to display the total pool balance when the wallet is disconnected and modified the tooltip to provide context-sensitive information.

Backend adjustments:

* [`dapp/src/utils/acreApi.ts`](diffhunk://#diff-0d8a6f1ae9db41b7ed6c24c22ae775fe1bf0f6c4c56ddcacf0aba716c2400becR40): Modified `getPointsData` to include `totalPool` in the response.