### PR TITLE
Switch deposit transaction to Wallet API Bitcoin module

### DIFF
--- a/dapp/manifests/ledger-live/ledger-live-manifest-development.json
+++ b/dapp/manifests/ledger-live/ledger-live-manifest-development.json
@@ -23,6 +23,7 @@
     "account.list",
     "bitcoin.getAddress",
     "bitcoin.getPublicKey",
+    "transaction.signAndBroadcast",
     "custom.acre.messageSign",
     "custom.acre.transactionSignAndBroadcast"
   ],

--- a/dapp/manifests/ledger-live/ledger-live-manifest-mainnet.json
+++ b/dapp/manifests/ledger-live/ledger-live-manifest-mainnet.json
@@ -23,6 +23,7 @@
     "account.list",
     "bitcoin.getAddress",
     "bitcoin.getPublicKey",
+    "transaction.signAndBroadcast",
     "custom.acre.messageSign",
     "custom.acre.transactionSignAndBroadcast"
   ],

--- a/dapp/manifests/ledger-live/ledger-live-manifest-testnet.json
+++ b/dapp/manifests/ledger-live/ledger-live-manifest-testnet.json
@@ -23,6 +23,7 @@
     "account.list",
     "bitcoin.getAddress",
     "bitcoin.getPublicKey",
+    "transaction.signAndBroadcast",
     "custom.acre.messageSign",
     "custom.acre.transactionSignAndBroadcast"
   ],

--- a/dapp/manifests/ledger-live/ledger-manifest-template.json
+++ b/dapp/manifests/ledger-live/ledger-manifest-template.json
@@ -23,6 +23,7 @@
     "account.list",
     "bitcoin.getAddress",
     "bitcoin.getPublicKey",
+    "transaction.signAndBroadcast",
     "custom.acre.messageSign",
     "custom.acre.transactionSignAndBroadcast"
   ],

--- a/dapp/src/utils/orangekit/ledger-live/bitcoin-provider.ts
+++ b/dapp/src/utils/orangekit/ledger-live/bitcoin-provider.ts
@@ -173,16 +173,15 @@ export default class AcreLedgerLiveBitcoinProvider
       throw new Error("Connect first")
     }
 
+    // TODO: In the current version of Acre module, sending Bitcoin transactions
+    // is not supported. Use the custom Acre module to send Bitcoin transaction
+    // once it works correctly.
     const txHash = await tryRequest<string>()(() =>
-      this.#walletApiClient.custom.acre.transactionSignAndBroadcast(
-        this.#account!.id,
-        {
-          family: "bitcoin",
-          amount: new BigNumber(satoshis),
-          recipient: to,
-        },
-        { hwAppId: this.#hwAppId },
-      ),
+      this.#walletApiClient.transaction.signAndBroadcast(this.#account!.id, {
+        family: "bitcoin",
+        amount: new BigNumber(satoshis),
+        recipient: to,
+      }),
     )
 
     return txHash

--- a/dapp/src/utils/orangekit/ledger-live/tests/bitcoin-provider.test.ts
+++ b/dapp/src/utils/orangekit/ledger-live/tests/bitcoin-provider.test.ts
@@ -42,6 +42,9 @@ describe("AcreLedgerLiveBitcoinProvider", () => {
         messageSign: vi.fn(),
       },
     },
+    transaction: {
+      signAndBroadcast: vi.fn(),
+    },
     account: {
       list: vi.fn(),
       request: vi.fn(),
@@ -79,7 +82,7 @@ describe("AcreLedgerLiveBitcoinProvider", () => {
         let result: string
 
         beforeAll(async () => {
-          mockedWalletApiClient.custom.acre.transactionSignAndBroadcast.mockResolvedValue(
+          mockedWalletApiClient.transaction.signAndBroadcast.mockResolvedValue(
             mockedTxHash,
           )
 
@@ -88,16 +91,12 @@ describe("AcreLedgerLiveBitcoinProvider", () => {
 
         it("should send transaction via Acre custom module", () => {
           expect(
-            mockedWalletApiClient.custom.acre.transactionSignAndBroadcast,
-          ).toHaveBeenCalledWith(
-            mockedAccount.id,
-            {
-              family: "bitcoin",
-              amount: new BigNumber(satoshis),
-              recipient: bitcoinAddress,
-            },
-            { hwAppId },
-          )
+            mockedWalletApiClient.transaction.signAndBroadcast,
+          ).toHaveBeenCalledWith(mockedAccount.id, {
+            family: "bitcoin",
+            amount: new BigNumber(satoshis),
+            recipient: bitcoinAddress,
+          })
         })
 
         it("should return transaction hash", () => {


### PR DESCRIPTION
Switch deposit transaction to Wallet API Bitcoin module. Currently, we're using the Acre custom module to send Bitcoin transactions for the deposit. Since it doesn't work and the fix is on the way, we need to switch to the regular Bitcoin module as a workaround for E2E testing.