### PR TITLE
Update URL for testnet subgraph

### DIFF
--- a/sdk/src/acre.ts
+++ b/sdk/src/acre.ts
@@ -96,7 +96,7 @@ class Acre {
     const acreSubgraphApiUrl =
       network === BitcoinNetwork.Mainnet
         ? `https://gateway-arbitrum.network.thegraph.com/api/${subgraphApiKey}/subgraphs/id/DJfS9X5asHtFEdAPikBcSLw8jtKmFcbReQVEa2iY9C9`
-        : "https://api.studio.thegraph.com/query/73600/acre/version/latest"
+        : "https://api.studio.thegraph.com/query/73600/acre-sepolia/version/latest"
 
     const subgraph = new AcreSubgraphApi(acreSubgraphApiUrl)
 


### PR DESCRIPTION
We update the URL for the testnet subgraph to the new one, after the project slug was changed in the Graph.