### PR TITLE
dApp: Fetch TVL cap from Acre API

### DIFF
--- a/dapp/src/constants/staking.ts
+++ b/dapp/src/constants/staking.ts
@@ -1,4 +1,2 @@
 // TODO: Read the value from the SDK, once we expose it
 export const MINIMUM_BALANCE = BigInt(String(5e6)) // 0.05 BTC
-
-export const TOTAL_VALUE_LOCKED_CAP = 1250 // 1250 BTC

--- a/dapp/src/hooks/useStatistics.ts
+++ b/dapp/src/hooks/useStatistics.ts
@@ -1,8 +1,4 @@
-import {
-  queryKeysFactory,
-  REFETCH_INTERVAL_IN_MILLISECONDS,
-  TOTAL_VALUE_LOCKED_CAP,
-} from "#/constants"
+import { queryKeysFactory, REFETCH_INTERVAL_IN_MILLISECONDS } from "#/constants"
 import { acreApi } from "#/utils"
 import { useQuery } from "@tanstack/react-query"
 
@@ -17,14 +13,13 @@ const useStatistics = () => {
 
   const bitcoinTvl = data?.btc ?? 0
   const usdTvl = data?.usd ?? 0
+  const tvlCap = data?.cap ?? 0
 
-  const isCapExceeded = bitcoinTvl > TOTAL_VALUE_LOCKED_CAP
+  const isCapExceeded = bitcoinTvl > tvlCap
 
-  const progress = isCapExceeded
-    ? 100
-    : Math.floor((bitcoinTvl / TOTAL_VALUE_LOCKED_CAP) * 100)
+  const progress = isCapExceeded ? 100 : Math.floor((bitcoinTvl / tvlCap) * 100)
 
-  const remaining = isCapExceeded ? 0 : TOTAL_VALUE_LOCKED_CAP - bitcoinTvl
+  const remaining = isCapExceeded ? 0 : tvlCap - bitcoinTvl
 
   return {
     tvl: {
@@ -33,6 +28,7 @@ const useStatistics = () => {
       usdValue: usdTvl,
       isCapExceeded,
       remaining,
+      cap: tvlCap,
     },
   }
 }

--- a/dapp/src/pages/DashboardPage/AcreTVLProgress.tsx
+++ b/dapp/src/pages/DashboardPage/AcreTVLProgress.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import {
   StackProps,
   useMultiStyleConfig,
@@ -12,21 +12,24 @@ import { BitcoinIcon } from "#/assets/icons"
 import { CurrencyBalance } from "#/components/shared/CurrencyBalance"
 import ProgressBar from "#/components/shared/ProgressBar"
 import { TextMd, TextXs } from "#/components/shared/Typography"
-import { TOTAL_VALUE_LOCKED_CAP } from "#/constants"
 
 type AcreTVLProgressProps = StackProps
 
 const STEP_COUNT = 5
 
-const STEPS = Array(STEP_COUNT)
-  .fill(0)
-  .map(
-    (_, index) => (index + 1) * Math.floor(TOTAL_VALUE_LOCKED_CAP / STEP_COUNT),
-  )
-
 export function AcreTVLProgress(props: AcreTVLProgressProps) {
   const styles = useMultiStyleConfig("AcreTVLProgress")
   const { tvl } = useStatistics()
+
+  const steps = useMemo(
+    () =>
+      tvl.cap > 0
+        ? Array(STEP_COUNT)
+            .fill(0)
+            .map((_, index) => (index + 1) * Math.floor(tvl.cap / STEP_COUNT))
+        : [],
+    [tvl.cap],
+  )
 
   return (
     <Box sx={styles.container} {...props}>
@@ -47,7 +50,7 @@ export function AcreTVLProgress(props: AcreTVLProgressProps) {
 
         <VStack sx={styles.progressWrapper}>
           <HStack sx={styles.progressLabelsWrapper}>
-            {STEPS.map((value) => (
+            {steps.map((value) => (
               <TextXs key={value} sx={styles.progressLabel}>
                 {value}
               </TextXs>

--- a/dapp/src/utils/acreApi.ts
+++ b/dapp/src/utils/acreApi.ts
@@ -38,7 +38,6 @@ type PointsDataResponse = {
   dropAt: number
   isCalculationInProgress: boolean
   totalPool: string
-  cap: string
 }
 
 const getPointsData = async () => {
@@ -49,7 +48,6 @@ const getPointsData = async () => {
     dropAt: response.data.dropAt,
     isCalculationInProgress: response.data.isCalculationInProgress,
     totalPool: Number(response.data.totalPool),
-    cap: response.data.cap,
   }
 }
 

--- a/dapp/src/utils/acreApi.ts
+++ b/dapp/src/utils/acreApi.ts
@@ -38,6 +38,7 @@ type PointsDataResponse = {
   dropAt: number
   isCalculationInProgress: boolean
   totalPool: string
+  cap: string
 }
 
 const getPointsData = async () => {
@@ -48,6 +49,7 @@ const getPointsData = async () => {
     dropAt: response.data.dropAt,
     isCalculationInProgress: response.data.isCalculationInProgress,
     totalPool: Number(response.data.totalPool),
+    cap: response.data.cap,
   }
 }
 
@@ -112,6 +114,7 @@ type GetStatisticsResponse = {
   tvl: {
     usd: number
     btc: number
+    cap: number
   }
 }
 


### PR DESCRIPTION
### Context
This pull request updates the handling of the total value locked (TVL) cap in the staking and statistics modules, removing hardcoded values and ensuring the cap is dynamically fetched from the API. The most important changes include removing the `TOTAL_VALUE_LOCKED_CAP` constant, updating the `useStatistics` hook to use the dynamic cap value, and modifying the `AcreTVLProgress` component to reflect these changes. It is required to ensure the TVL cap is gathered from the single source of truth.

### Changes
* `dapp/src/constants/staking.ts`: Removed the `TOTAL_VALUE_LOCKED_CAP` constant.
* `dapp/src/hooks/useStatistics.ts`: Removed the import of `TOTAL_VALUE_LOCKED_CAP` and updated the logic to use the dynamic cap value from the API.
* `dapp/src/pages/DashboardPage/AcreTVLProgress.tsx` Updated the `AcreTVLProgress` component to use the dynamic cap value from the `useStatistics` hook and memoized the steps calculation.
* `dapp/src/utils/acreApi.ts`: Added the `cap` field to the `PointsDataResponse` and `GetStatisticsResponse` types and included it in the `getPointsData` function response.