### PR TITLE
Fix grammatical error in the validation text

### DIFF
--- a/dapp/src/utils/forms.ts
+++ b/dapp/src/utils/forms.ts
@@ -52,7 +52,7 @@ export function validateTokenAmount(
   if (isMaximumValueExceeded) return ERRORS_BY_ACTION_TYPE.EXCEEDED_VALUE
   if (!isMinimumValueFulfilled)
     return ERRORS_BY_ACTION_TYPE.INSUFFICIENT_VALUE(
-      actionType === ACTION_FLOW_TYPES.STAKE ? "deposit" : "withdraw",
+      actionType === ACTION_FLOW_TYPES.STAKE ? "deposit" : "withdrawal",
       fixedPointNumberToString(minValue, decimals),
     )
 


### PR DESCRIPTION
Closes https://github.com/thesis/acre/issues/855

This PR fixes grammatical error in the validation text.

**Before**

> The amount is below the minimum required withdraw of 0.01 BTC.

**After**

> The amount is below the minimum required withdrawal of 0.01 BTC.


![Screenshot 2024-11-14 at 08 20 15](https://github.com/user-attachments/assets/9bb39a6c-f6b7-4f1b-8e9f-2e5bb0d09129)
