### PR TITLE
Capture console.error in dApp with Sentry

### DIFF
--- a/dapp/src/sentry/index.ts
+++ b/dapp/src/sentry/index.ts
@@ -3,7 +3,13 @@ import * as Sentry from "@sentry/react"
 const initialize = (dsn: string) => {
   Sentry.init({
     dsn,
-    integrations: [Sentry.browserTracingIntegration()],
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.captureConsoleIntegration({ levels: ["error"] }),
+    ],
+    // Attach stacktrace to errors logged by `console.error`. This is useful for
+    // the `captureConsoleIntegration` integration.
+    attachStacktrace: true,
     // Performance Monitoring
     tracesSampleRate: 0.1,
   })


### PR DESCRIPTION
The dApp sometime catches errors and logs them to console without bubbling it up. This makes Sentry miss some errors. This PR captures console.error and sends it to Sentry using the `CaptureConsole` plugin: https://docs.sentry.io/platforms/javascript/configuration/integrations/captureconsole/