### PR TITLE
dApp: `AcreTVLProgress` component mask fix

### DIFF
--- a/dapp/src/theme/AcreTVLProgress.ts
+++ b/dapp/src/theme/AcreTVLProgress.ts
@@ -20,10 +20,11 @@ const containerStyles = defineStyle({
   color: "gold.200",
   mask: 'linear-gradient(0, black, black), url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDA4IiBoZWlnaHQ9IjI4IiB2aWV3Qm94PSIwIDAgMjY2LjcgNy40MDgiPgogICAgPHBhdGgKICAgICAgICBkPSJNMjY2LjcgMGEzLjE3NSAzLjE3NSAwIDAgMS0zLjE3NSAzLjE3NUg3OC43NDdjLTEuMTIyIDAtMi4yLjQ0Ni0yLjk5MyAxLjI0TDc0IDYuMTY5YTQuMjMzIDQuMjMzIDAgMCAxLTIuOTkzIDEuMjRIMjY2LjdaTTAgNC4yMzN2My4xNzVoMy4xNzVBMy4xNzUgMy4xNzUgMCAwIDEgMCA0LjIzMyIKICAgICAgICBzdHlsZT0iZmlsbDojMDAwO3N0cm9rZTpub25lO3N0cm9rZS13aWR0aDouMjY0NTgzO3N0cm9rZS1vcGFjaXR5OjEiIC8+Cjwvc3ZnPg==")',
   maskPosition: "100% 100%",
-  clipPath: "inset(0 1px 0 0 round 12px)",
+  clipPath: "inset(0 0.5px 0.5px 0)",
   maskComposite: "exclude",
   maskRepeat: "no-repeat",
   maskSize: "contain",
+  rounded: "12px 12px 0 0",
 })
 const wrapperStyles = defineStyle({
   px: 5,

--- a/dapp/src/theme/AcreTVLProgress.ts
+++ b/dapp/src/theme/AcreTVLProgress.ts
@@ -18,11 +18,12 @@ const containerStyles = defineStyle({
   bgGradient:
     "linear(to-r, transparent, rgba(255, 122, 0, 0.2) 10%, rgba(243, 73, 0, 0.25) 20%, transparent 30%)",
   color: "gold.200",
-  mask: 'linear-gradient(0, black, black), url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3MzkuNjI3IiBoZWlnaHQ9IjI4IiBmaWxsPSJub25lIj48cGF0aCBkPSJNNzM5LjYyNyAwYzAgNi42MjctNS4zNyAxMi0xMiAxMkgyOS4yNTRhMTUuOTk2IDE1Ljk5NiAwIDAgMC0xMS4zMTMgNC42ODZsLTYuNjI4IDYuNjI4QzguMzEzIDI2LjMxNSA0LjI0MyAyOCAwIDI4aDczOS42Mjd6IiBzdHlsZT0iZmlsbDojMDAwO2ZpbGwtb3BhY2l0eToxO3N0cm9rZTpub25lO3N0cm9rZS13aWR0aDo4O3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZCIvPjwvc3ZnPg==")',
+  mask: 'linear-gradient(0, black, black), url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDA4IiBoZWlnaHQ9IjI4IiB2aWV3Qm94PSIwIDAgMjY2LjcgNy40MDgiPgogICAgPHBhdGgKICAgICAgICBkPSJNMjY2LjcgMGEzLjE3NSAzLjE3NSAwIDAgMS0zLjE3NSAzLjE3NUg3OC43NDdjLTEuMTIyIDAtMi4yLjQ0Ni0yLjk5MyAxLjI0TDc0IDYuMTY5YTQuMjMzIDQuMjMzIDAgMCAxLTIuOTkzIDEuMjRIMjY2LjdaTTAgNC4yMzN2My4xNzVoMy4xNzVBMy4xNzUgMy4xNzUgMCAwIDEgMCA0LjIzMyIKICAgICAgICBzdHlsZT0iZmlsbDojMDAwO3N0cm9rZTpub25lO3N0cm9rZS13aWR0aDouMjY0NTgzO3N0cm9rZS1vcGFjaXR5OjEiIC8+Cjwvc3ZnPg==")',
   maskPosition: "100% 100%",
   clipPath: "inset(0 1px 0 0 round 12px)",
   maskComposite: "exclude",
   maskRepeat: "no-repeat",
+  maskSize: "contain",
 })
 const wrapperStyles = defineStyle({
   px: 5,


### PR DESCRIPTION
The `AcreTVLProgress` component was not responsive looking bad on mobile. This PR fixes it.
The only flaw are bottom rounded corners which are not very rounded on mobile. It's baked into the mask so it scales accordingly to the viewport - the smaller screen is, the smaller is the radius. It's unavoidable. Still looks better than before.

Before:
<img width="609" alt="image" src="https://github.com/user-attachments/assets/c8b4239d-d1e6-4146-af36-b3e1aaa33ab9">

After:
<img width="616" alt="image" src="https://github.com/user-attachments/assets/7c4d7aa9-e037-4d70-b318-3673294daf20">

