### PR TITLE
Enable more Sentry integrations

### DIFF
--- a/dapp/src/sentry/index.ts
+++ b/dapp/src/sentry/index.ts
@@ -7,6 +7,7 @@ const initialize = (dsn: string) => {
       Sentry.browserTracingIntegration(),
       Sentry.captureConsoleIntegration({ levels: ["error"] }),
       Sentry.extraErrorDataIntegration(),
+      Sentry.httpClientIntegration(),
     ],
     // Attach stacktrace to errors logged by `console.error`. This is useful for
     // the `captureConsoleIntegration` integration.

--- a/dapp/src/sentry/index.ts
+++ b/dapp/src/sentry/index.ts
@@ -6,6 +6,7 @@ const initialize = (dsn: string) => {
     integrations: [
       Sentry.browserTracingIntegration(),
       Sentry.captureConsoleIntegration({ levels: ["error"] }),
+      Sentry.extraErrorDataIntegration(),
     ],
     // Attach stacktrace to errors logged by `console.error`. This is useful for
     // the `captureConsoleIntegration` integration.


### PR DESCRIPTION
### Enable [ExtraErrorData](https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/extraerrordata/) integration in Sentry.

This integration serialized extra data attached to the error event. It is
useful to attach additional context to the error event, as currently the
objects are not serialized and are visible as `[Object]` in the Sentry dashboard.

### Enable [HttpClient](https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/httpclient/) integration in Sentry.

This integration will capture failed requests and responses in Sentry.

-----
Refs: [AENG-41](https://linear.app/thesis-co/issue/AENG-41).