### PR TITLE
Update estimated time for processing of small deposits to 2 hours

### DIFF
--- a/dapp/src/utils/activities.ts
+++ b/dapp/src/utils/activities.ts
@@ -21,12 +21,31 @@ export function getEstimatedDuration(
   amount: bigint,
   type: ActivityType,
 ): string {
+  // Withdrawal duration is related to the tBTC redemption process, which takes
+  // approximately 5 - 7 hours. We use the average value of 6 hours.
   if (isWithdrawType(type)) return "6 hours"
 
-  if (amount < MIN_LIMIT_VALUE_DURATION) return "1 hour"
-
-  if (amount >= MIN_LIMIT_VALUE_DURATION && amount < MAX_LIMIT_VALUE_DURATION)
-    return "2 hours"
-
+  // Deposit duration is related to the tBTC minting process, which varies based
+  // on the amount of BTC deposited.
+  // Each threshold requires a different number of Bitcoin transaction confirmations:
+  // <0.1 BTC: 1 Bitcoin block confirmation (~10 minutes),
+  // >=0.1 BTC and <1 BTC: 3 Bitcoin block confirmations (~30 minutes),
+  // >=1 BTC: 6 Bitcoin block confirmations (~60 minutes).
+  // The duration of the transaction minting process depends on the Bitcoin network
+  // congestion, and the fee paid by the user.
+  //
+  // After the required number of Bitcoin block confirmations, the tBTC optimistic
+  // minting process starts. The optimistic minting process takes approximately
+  // 1 hour to complete.
+  // After optimistic minting is completed, the Acre bots will finalize the deposit
+  // in no more than 10 minutes.
+  //
+  // We round the estimated duration up to the nearest hour.
+  //
+  // For <0.1 BTC estimated duration is around 1 hour 20 minutes.
+  if (amount < MIN_LIMIT_VALUE_DURATION) return "2 hours"
+  // For <1 BTC estimated duration is around 1 hours 40 minutes.
+  if (amount < MAX_LIMIT_VALUE_DURATION) return "2 hours"
+  // For >=1 BTC estimated duration is around 2 hours 10 minutes.
   return "3 hours"
 }

--- a/dapp/src/utils/tests/activities.test.ts
+++ b/dapp/src/utils/tests/activities.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { getEstimatedDuration } from "../activities"
+
+describe("Utils functions for activities", () => {
+  describe("getEstimatedDuration", () => {
+    describe("withdraw", () => {
+      describe.each([
+        // 0.01 BTC
+        { value: 0.01, expectedResult: "6 hours" },
+        // 0.1 BTC
+        { value: 0.1, expectedResult: "6 hours" },
+        // 1 BTC
+        { value: 1, expectedResult: "6 hours" },
+        // 10 BTC
+        { value: 10, expectedResult: "6 hours" },
+      ])("when it is $value BTC", ({ value, expectedResult }) => {
+        it(`should return ${expectedResult}`, () => {
+          expect(getEstimatedDuration(BigInt(value * 1e8), "withdraw")).toEqual(
+            expectedResult,
+          )
+        })
+      })
+    })
+
+    describe("deposit", () => {
+      describe.each([
+        // 0.0001 BTC
+        { value: 0.0001, expectedResult: "2 hours" },
+        // 0.001 BTC
+        { value: 0.001, expectedResult: "2 hours" },
+        // 0.01 BTC
+        { value: 0.01, expectedResult: "2 hours" },
+        // 0.09 BTC
+        { value: 0.09, expectedResult: "2 hours" },
+        // 0.1 BTC
+        { value: 0.1, expectedResult: "2 hours" },
+        // 0.9 BTC
+        { value: 0.9, expectedResult: "2 hours" },
+        // 1 BTC
+        { value: 1, expectedResult: "3 hours" },
+        // 10 BTC
+        { value: 10, expectedResult: "3 hours" },
+      ])("when it is $value BTC", ({ value, expectedResult }) => {
+        it(`should return ${expectedResult}`, () => {
+          expect(getEstimatedDuration(BigInt(value * 1e8), "deposit")).toEqual(
+            expectedResult,
+          )
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
The deposit duration for small deposits was increased from 1 hour to 2 hours. This change was made to reflect the actual time it takes for small deposits to be processed. We observed that small deposits generally take 1.5 hours to finalize, so we decided to round up for a better user experience.

Closes: https://github.com/thesis/acre/issues/884