### PR TITLE
Connect to account with direct navigation parameters

### DIFF
--- a/dapp/manifests/ledger-live/ledger-live-manifest-development.json
+++ b/dapp/manifests/ledger-live/ledger-live-manifest-development.json
@@ -23,6 +23,7 @@
     "account.list",
     "bitcoin.getAddress",
     "bitcoin.getPublicKey",
+    "bitcoin.getXPub",
     "transaction.signAndBroadcast",
     "custom.acre.messageSign",
     "custom.acre.transactionSignAndBroadcast"

--- a/dapp/manifests/ledger-live/ledger-live-manifest-mainnet.json
+++ b/dapp/manifests/ledger-live/ledger-live-manifest-mainnet.json
@@ -23,6 +23,7 @@
     "account.list",
     "bitcoin.getAddress",
     "bitcoin.getPublicKey",
+    "bitcoin.getXPub",
     "transaction.signAndBroadcast",
     "custom.acre.messageSign",
     "custom.acre.transactionSignAndBroadcast"

--- a/dapp/manifests/ledger-live/ledger-live-manifest-testnet.json
+++ b/dapp/manifests/ledger-live/ledger-live-manifest-testnet.json
@@ -23,6 +23,7 @@
     "account.list",
     "bitcoin.getAddress",
     "bitcoin.getPublicKey",
+    "bitcoin.getXPub",
     "transaction.signAndBroadcast",
     "custom.acre.messageSign",
     "custom.acre.transactionSignAndBroadcast"

--- a/dapp/manifests/ledger-live/ledger-manifest-template.json
+++ b/dapp/manifests/ledger-live/ledger-manifest-template.json
@@ -23,6 +23,7 @@
     "account.list",
     "bitcoin.getAddress",
     "bitcoin.getPublicKey",
+    "bitcoin.getXPub",
     "transaction.signAndBroadcast",
     "custom.acre.messageSign",
     "custom.acre.transactionSignAndBroadcast"

--- a/dapp/src/utils/orangekit/index.ts
+++ b/dapp/src/utils/orangekit/index.ts
@@ -107,6 +107,33 @@ async function verifySignInWithWalletMessage(
   return result.data
 }
 
+/**
+ * Finds the extended public key (xpub) of the user's account from URL. Users
+ * can be redirected to the exact app in the Ledger Live application. One of the
+ * parameters passed via URL is `accountId` - the ID of the user's account in
+ * Ledger Live.
+ * @see https://developers.ledger.com/docs/ledger-live/exchange/earn/liveapp#url-parameters-for-direct-navigation
+ *
+ * @param {string} url Request url
+ * @returns The extended public key (xpub) of the user's account if the search
+ *          parameter `accountId` exists in the URL. Otherwise `undefined`.
+ */
+function findXpubFromUrl(url: string): string | undefined {
+  const parsedUrl = new URL(url)
+
+  const accountId = parsedUrl.searchParams.get("accountId")
+
+  if (!accountId) return undefined
+
+  // The fourth value separated by `:` is extended public key. See the
+  // account ID template: `js:2:bitcoin_testnet:<xpub>:<address_type>`.
+  const xpubFromAccountId = accountId.split(":")[3]
+
+  if (!xpubFromAccountId) return undefined
+
+  return xpubFromAccountId
+}
+
 export default {
   getWalletInfo,
   isWalletInstalled,
@@ -119,4 +146,5 @@ export default {
   isWalletConnectionRejectedError,
   verifySignInWithWalletMessage,
   getOrangeKitLedgerLiveConnector,
+  findXpubFromUrl,
 }

--- a/dapp/src/utils/orangekit/ledger-live/tests/bitcoin-provider.test.ts
+++ b/dapp/src/utils/orangekit/ledger-live/tests/bitcoin-provider.test.ts
@@ -473,8 +473,6 @@ describe("AcreLedgerLiveBitcoinProvider", () => {
           })
         })
 
-        it("should get")
-
         it("should get zero address for all accounts", () => {
           expect(
             mockedWalletApiClient.bitcoin.getAddress,

--- a/dapp/src/utils/orangekit/ledger-live/tests/bitcoin-provider.test.ts
+++ b/dapp/src/utils/orangekit/ledger-live/tests/bitcoin-provider.test.ts
@@ -473,6 +473,8 @@ describe("AcreLedgerLiveBitcoinProvider", () => {
           })
         })
 
+        it("should get")
+
         it("should get zero address for all accounts", () => {
           expect(
             mockedWalletApiClient.bitcoin.getAddress,

--- a/dapp/src/wagmiConfig.ts
+++ b/dapp/src/wagmiConfig.ts
@@ -5,6 +5,7 @@ import { env } from "./constants"
 import { getLastUsedBtcAddress } from "./hooks/useLastUsedBtcAddress"
 import referralProgram, { EmbedApp } from "./utils/referralProgram"
 import { orangeKit } from "./utils"
+import { AcreLedgerLiveBitcoinProviderOptions } from "./utils/orangekit/ledger-live/bitcoin-provider"
 
 const isTestnet = env.USE_TESTNET
 const CHAIN_ID = isTestnet ? sepolia.id : mainnet.id
@@ -34,12 +35,19 @@ async function getWagmiConfig() {
   let createEmbedConnectorFn
   const embeddedApp = referralProgram.getEmbeddedApp()
   if (referralProgram.isEmbedApp(embeddedApp)) {
+    const lastUsedBtcAddress = getLastUsedBtcAddress()
+    const xpub = orangeKit.findXpubFromUrl(window.location.href)
+    const ledgerLiveConnectorOptions: AcreLedgerLiveBitcoinProviderOptions =
+      xpub
+        ? { tryConnectToAccountByXpub: xpub }
+        : {
+            tryConnectToAddress: lastUsedBtcAddress,
+          }
+
     const orangeKitLedgerLiveConnector =
       orangeKit.getOrangeKitLedgerLiveConnector({
         ...connectorConfig,
-        options: {
-          tryConnectToAddress: getLastUsedBtcAddress(),
-        },
+        options: ledgerLiveConnectorOptions,
       })
 
     const embedConnectorsMap: Record<


### PR DESCRIPTION
Closes: AENG-51

To ensure users are directed to the correct LiveApp page for specific actions (such as staking/unstaking) triggered from Ledger Live, the Acre dapp must implement URL parameters to support direct navigation.

We want to connect to the account passed via URL. The Ledger Live App passes the `accountId` parameter in URL when redirecting to Acre dapp. This parameter has the following pattern `js:2:bitcoin_testnet:<xpub>:<address_type>`. To connect to a given account we need to get the extended public key from this parameter.

To connect to a given account by xpub we define the new option in the provider: `tryConnectToAccountByXpub`. The Ledger Live Bitcoin provider will try to find this account and connect.