### PR TITLE
Log connection error

### DIFF
--- a/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
+++ b/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
@@ -129,6 +129,11 @@ export default function ConnectWalletButton({
       },
       onError: (error: OrangeKitError) => {
         const errorData = orangeKit.parseOrangeKitConnectionError(error)
+
+        if (errorData === CONNECTION_ERRORS.DEFAULT) {
+          console.error("Failed to connect", error)
+        }
+
         setConnectionError(errorData)
       },
     })


### PR DESCRIPTION
We are now logging connection errors to the console. This will help us debug connection issues, as the error will be reported to Sentry.

We're handling only the `DEFAULT` error type, as the other types are reported to the user in a modal.