### PR TITLE
Fix `subgraph-test` job

### DIFF
--- a/.github/workflows/subgraph.yaml
+++ b/.github/workflows/subgraph.yaml
@@ -97,7 +97,7 @@ jobs:
 
   subgraph-test:
     needs: [subgraph-codegen]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The Github Actions migrates the `ubuntu-latest` label to `ubuntu 24` see https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/

The subgraph does not support all platforms so we change the `runs-on` to `ubuntu-22.04`.