### PR TITLE
Update tooltips to match the style guide

### DIFF
--- a/dapp/src/theme/tooltipTheme.ts
+++ b/dapp/src/theme/tooltipTheme.ts
@@ -16,9 +16,10 @@ ChakraTooltip.defaultProps = { ...ChakraTooltip.defaultProps, hasArrow: true }
 const $arrowBg = cssVar("popper-arrow-bg")
 
 const baseStyle = defineStyle({
-  color: "surface.2",
+  fontWeight: "normal",
+  color: "ivoire.10",
   bg: "brown.100",
-  [$arrowBg.variable]: "brown.100",
+  [$arrowBg.variable]: "colors.brown.100",
 })
 
 const sizeXs = defineStyle({


### PR DESCRIPTION
This PR updates tooltips to match the [style guide](https://www.figma.com/design/1jAHRz9Kh43x7WpjiZ1tq2/UI-Styleguide?node-id=1566-2327&m=dev). 

![Screenshot 2024-12-23 at 12 39 43](https://github.com/user-attachments/assets/961071d8-55ab-4f6b-b857-a7e75d864a3e)
