### PR TITLE
fix: Remove redundant __Ownable_init call in Ownable2StepUpgradeable

### DIFF
--- a/solidity/contracts/AcreMultiAssetVault.sol
+++ b/solidity/contracts/AcreMultiAssetVault.sol
@@ -106,19 +106,18 @@ contract AcreMultiAssetVault is
         address[] memory _supportedAssets
     ) public initializer {
         __Ownable2Step_init();
-        __Ownable_init(_owner);
         __ReentrancyGuard_init();
 
-        if (_mezoPortal == address(0)) {
+          if (_mezoPortal == address(0)) {
             revert ZeroAddress();
-        }
+    }
 
         mezoPortal = IMezoPortal(_mezoPortal);
 
         for (uint256 i = 0; i < _supportedAssets.length; i++) {
             _addSupportedAsset(_supportedAssets[i]);
-        }
     }
+}
 
     /// @notice Adds an asset to the list of assets supported by the vault.
     /// @dev This function can only be called by the owner.


### PR DESCRIPTION
While working with `Ownable2StepUpgradeable` (part of OpenZeppelin Upgradeable contracts), I noticed that the function `__Ownable_init` does not exist. Instead, `__Ownable2Step_init` is used, which is already correctly called in the code. The line `__Ownable_init(_owner);` is redundant and can be safely removed to clean up the implementation.  

This change ensures the code aligns with the intended design of the `Ownable2StepUpgradeable` contract.