### PR TITLE
Fix `VITE_FEATURE_GATING_DAPP_ENABLED` feature flag

### DIFF
--- a/dapp/src/pages/AccessPage/index.tsx
+++ b/dapp/src/pages/AccessPage/index.tsx
@@ -1,15 +1,19 @@
 import React from "react"
 import { useAppNavigate } from "#/hooks"
 import GateModal from "#/components/GateModal"
+import { featureFlags } from "#/constants"
+import { Navigate } from "react-router-dom"
 
 export default function AccessPage() {
   const navigate = useAppNavigate()
 
-  return (
+  return featureFlags.GATING_DAPP_ENABLED ? (
     <GateModal
       closeModal={() => {
         navigate("/dashboard")
       }}
     />
+  ) : (
+    <Navigate to="/welcome" />
   )
 }

--- a/dapp/src/router/index.tsx
+++ b/dapp/src/router/index.tsx
@@ -20,9 +20,7 @@ const mainLayoutLoader: LoaderFunction = ({ request }) => {
   const embedApp = referralProgram.getEmbeddedApp(request.url)
 
   if (referralProgram.isEmbedApp(embedApp)) {
-    const shouldRedirectToWelcomeModal = !shouldDisplayWelcomeModal()
-
-    return shouldRedirectToWelcomeModal
+    return shouldDisplayWelcomeModal()
       ? routerUtils.redirectWithSearchParams(request.url, "/welcome")
       : routerUtils.redirectWithSearchParams(request.url, "/dashboard")
   }


### PR DESCRIPTION
Respect the `VITE_FEATURE_GATING_DAPP_ENABLED` feature flag when redirecting to `/access` or `/welcome` page.