### PR TITLE
Deposit fees

### DIFF
--- a/dapp/src/components/TransactionModal/ActiveUnstakingStep/SignMessageModal.tsx
+++ b/dapp/src/components/TransactionModal/ActiveUnstakingStep/SignMessageModal.tsx
@@ -129,7 +129,10 @@ export default function SignMessageModal() {
             status: "pending",
             // This is a requested amount. The amount of BTC received will be
             // around: `amount - transactionFee.total`.
-            amount: amount - transactionFee.acre,
+            // TODO: Based on the comment above: shouldn't we use total fee
+            // instead of only Acre fee. We can also use `estimatedAmount` from
+            // `useTransactionDetails` hook.
+            amount: amount - transactionFee.acre.fee,
             initializedAt: timeUtils.dateToUnixTimestamp(),
             // The message is signed immediately after the initialization.
             finalizedAt: timeUtils.dateToUnixTimestamp(),

--- a/dapp/src/components/TransactionModal/FeesTooltip/FeesTooltipItem.tsx
+++ b/dapp/src/components/TransactionModal/FeesTooltip/FeesTooltipItem.tsx
@@ -1,33 +1,59 @@
 import React from "react"
-import { ListItem, Text } from "@chakra-ui/react"
+import { Box, ListItem, Text } from "@chakra-ui/react"
 import CurrencyBalance, {
   CurrencyBalanceProps,
 } from "#/components/shared/CurrencyBalance"
 import { currencies } from "#/constants"
 
-type FeesItemType = CurrencyBalanceProps & {
+type FeesItemProps = CurrencyBalanceProps & {
   label: string
+  isReimbursable?: boolean
+  reimbursableFeeLabel?: string
 }
-
 export default function FeesTooltipItem({
   label,
   amount,
+  isReimbursable = false,
+  reimbursableFeeLabel,
   ...props
-}: FeesItemType) {
+}: FeesItemProps) {
   return (
-    <ListItem display="flex" justifyContent="space-between">
-      <Text size="sm" color="white">
-        {label}
-      </Text>
-      <CurrencyBalance
-        size="sm"
-        amount={amount}
-        color="surface.4"
-        fontWeight="semibold"
-        desiredDecimals={currencies.DESIRED_DECIMALS_FOR_FEE}
-        withRoundUp
-        {...props}
-      />
+    <ListItem display="flex" flexDirection="column">
+      <Box display="flex" justifyContent="space-between">
+        <Text size="sm" color="white">
+          {label}
+        </Text>
+        <CurrencyBalance
+          size="sm"
+          amount={amount}
+          color="surface.4"
+          fontWeight="semibold"
+          desiredDecimals={currencies.DESIRED_DECIMALS_FOR_FEE}
+          withRoundUp
+          as={isReimbursable ? "s" : undefined}
+          {...props}
+        />
+      </Box>
+
+      {isReimbursable && (
+        <>
+          <Box marginLeft="auto" color="green.30">
+            <CurrencyBalance
+              currency="bitcoin"
+              size="sm"
+              amount={0}
+              fontWeight="400"
+              desiredDecimals={2}
+              withRoundUp
+            />
+          </Box>
+          <Box marginLeft="auto" color="green.30">
+            <Text size="sm" color="brown.40">
+              {reimbursableFeeLabel}
+            </Text>
+          </Box>
+        </>
+      )}
     </ListItem>
   )
 }

--- a/dapp/src/components/TransactionModal/FeesTooltip/index.tsx
+++ b/dapp/src/components/TransactionModal/FeesTooltip/index.tsx
@@ -19,17 +19,31 @@ const mapFeeToLabel = (feeId: keyof AcreFee) => {
   }
 }
 
+const mapFeeToReimbursableFeeLabel = (feeId: keyof AcreFee) => {
+  switch (feeId) {
+    case "tbtc":
+      return "*tBTC Bridge fee covered by Acre"
+    case "acre":
+    default:
+      return ""
+  }
+}
+
 export default function FeesTooltip({ fees }: Props) {
   return (
     <TooltipIcon
       placement="right"
       label={
-        <List spacing={0.5} minW={60}>
-          {Object.entries(fees).map(([feeKey, feeValue]) => (
+        <List spacing={2} minW={60}>
+          {Object.entries(fees).map(([feeKey, { fee, isReimbursable }]) => (
             <FeesTooltipItem
               key={feeKey}
               label={mapFeeToLabel(feeKey as keyof AcreFee)}
-              amount={feeValue}
+              amount={fee}
+              isReimbursable={isReimbursable}
+              reimbursableFeeLabel={mapFeeToReimbursableFeeLabel(
+                feeKey as keyof AcreFee,
+              )}
               currency="bitcoin"
             />
           ))}

--- a/dapp/src/types/fee.ts
+++ b/dapp/src/types/fee.ts
@@ -1,5 +1,10 @@
+export type ProtocolFee = {
+  fee: bigint
+  isReimbursable?: boolean
+}
+
 export type Fee = {
-  tbtc: bigint
-  acre: bigint
+  tbtc: ProtocolFee
+  acre: ProtocolFee
   total: bigint
 }


### PR DESCRIPTION
WIP...

Some of the fees may be covered by Acre, so we want to display information about this in the tooltip.


<details>
  <summary>Screenshots</summary>

![obraz](https://github.com/user-attachments/assets/4d35fef9-7b83-417e-80ac-8a180b92c1e8)

</details>

TODO:

- [ ] update the `estimateDepositFee` function in SDK. Take into account the reimbursement threshold from #942 and the tBTC balance of the `FeesReimbursementPool` contract.
- [ ] unit tests.