### PR TITLE
Fix "You will deposit/receive" amount calculation

### DIFF
--- a/dapp/src/components/TransactionModal/ActiveUnstakingStep/UnstakeFormModal/UnstakeDetails.tsx
+++ b/dapp/src/components/TransactionModal/ActiveUnstakingStep/UnstakeFormModal/UnstakeDetails.tsx
@@ -13,14 +13,14 @@ import TransactionDetailsAmountItem from "#/components/shared/TransactionDetails
 import FeesTooltip from "../../FeesTooltip"
 
 function UnstakeDetails({ currency }: { currency: CurrencyType }) {
-  const { value = 0n } = useFormField<bigint | undefined>(
-    TOKEN_AMOUNT_FIELD_NAME,
-  )
+  const { value = 0n } = useFormField<bigint>(TOKEN_AMOUNT_FIELD_NAME)
   const minWithdrawAmount = useMinWithdrawAmount()
-  const amount = value >= minWithdrawAmount ? value : 0n
-  const details = useTransactionDetails(amount, ACTION_FLOW_TYPES.UNSTAKE)
+  const { transactionFee, estimatedAmount } = useTransactionDetails(
+    value >= minWithdrawAmount ? value : 0n,
+    ACTION_FLOW_TYPES.UNSTAKE,
+  )
 
-  const { total, ...restFees } = details.transactionFee
+  const { total: totalFees, ...restFees } = transactionFee
 
   return (
     <List spacing={3} mt={10}>
@@ -31,7 +31,7 @@ function UnstakeDetails({ currency }: { currency: CurrencyType }) {
         tooltip={<FeesTooltip fees={restFees} />}
         from={{
           currency,
-          amount: total,
+          amount: totalFees,
           desiredDecimals: currencies.DESIRED_DECIMALS_FOR_FEE,
           withRoundUp: true,
         }}
@@ -43,7 +43,7 @@ function UnstakeDetails({ currency }: { currency: CurrencyType }) {
         label="You will receive"
         from={{
           currency,
-          amount: details.estimatedAmount,
+          amount: estimatedAmount,
         }}
       />
     </List>

--- a/dapp/src/hooks/useTransactionDetails.ts
+++ b/dapp/src/hooks/useTransactionDetails.ts
@@ -2,7 +2,7 @@ import { ACTION_FLOW_TYPES, ActionFlowType } from "#/types"
 import useTransactionFee from "./useTransactionFee"
 
 export default function useTransactionDetails(
-  amount: bigint | undefined,
+  amount: bigint,
   flow: ActionFlowType = ACTION_FLOW_TYPES.STAKE,
 ) {
   const { data: transactionFee } = useTransactionFee(amount, flow)
@@ -10,6 +10,6 @@ export default function useTransactionDetails(
   return {
     amount,
     transactionFee,
-    estimatedAmount: amount ?? 0n - transactionFee.total,
+    estimatedAmount: amount - transactionFee.total,
   }
 }


### PR DESCRIPTION
Closes: ACR-133 ACR-134
Closes #1000 #999

There was a logical error. By fallbacking to zero it didn't have the base to subtract from. 
By removing the zero value fallback it is resolved. It is applicable for both deposits and withdrawals.

Before:
<img width="711" height="475" alt="image" src="https://github.com/user-attachments/assets/05c4730e-32a7-4da9-a9fb-cfa292402a39" />

After:
<img width="559" height="370" alt="image" src="https://github.com/user-attachments/assets/148a167a-191e-4877-91f3-fdf03645cb69" />
