### PR TITLE
Fix Xverse 2.0 wallet detection on fresh page loads

### DIFF
--- a/dapp/src/vite-env.d.ts
+++ b/dapp/src/vite-env.d.ts
@@ -40,4 +40,5 @@ interface InjectedProvider {
 interface Window {
   unisat?: InjectedProvider
   okxwallet?: { bitcoin: InjectedProvider }
+  XverseProviders?: { BitcoinProvider?: object }
 }

--- a/dapp/src/wagmiConfig.ts
+++ b/dapp/src/wagmiConfig.ts
@@ -21,7 +21,48 @@ const transports = chains.reduce(
   {},
 )
 
+/**
+ * Waits for the Xverse wallet provider to become available.
+ * Xverse 2.0+ injects its provider asynchronously and announces readiness via
+ * the `bitcoin:providers` window event (SatsConnect v2 standard). Without this
+ * wait, `getOrangeKitXverseConnector` captures `undefined` and the wallet
+ * permanently appears as "not installed".
+ */
+function waitForXverseProvider(timeoutMs = 1500): Promise<void> {
+  return new Promise((resolve) => {
+    if (window.XverseProviders?.BitcoinProvider) {
+      resolve()
+      return
+    }
+
+    let settled = false
+
+    const onProvider = () => {
+      if (window.XverseProviders?.BitcoinProvider) {
+        settled = true
+        clearTimeout(timer) // eslint-disable-line @typescript-eslint/no-use-before-define
+        window.removeEventListener("bitcoin:providers", onProvider)
+        resolve()
+      }
+    }
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true
+        window.removeEventListener("bitcoin:providers", onProvider)
+        resolve() // Resolve even on timeout — wallet may not be installed
+      }
+    }, timeoutMs)
+
+    window.addEventListener("bitcoin:providers", onProvider)
+  })
+}
+
 async function getWagmiConfig() {
+  // Wait for async wallet provider injection (Xverse 2.0+) before creating
+  // connectors. The app shows a splash screen during this time.
+  await waitForXverseProvider()
+
   const {
     getOrangeKitUnisatConnector,
     getOrangeKitOKXConnector,


### PR DESCRIPTION
## Summary
- Xverse 2.0 changed provider injection from synchronous to asynchronous, announcing readiness via the `bitcoin:providers` window event (SatsConnect v2 standard)
- OrangeKit's `getOrangeKitXverseConnector` captures `window.XverseProviders.BitcoinProvider` synchronously at config creation time — when it hasn't injected yet, the connector is permanently created with `undefined`, so `isWalletInstalled` returns `false` and users are redirected to the download page for a wallet they already have
- Added `waitForXverseProvider()` in `wagmiConfig.ts` that listens for the `bitcoin:providers` event (with a 1.5s timeout) before creating wagmi connectors, ensuring the provider is available when OrangeKit runs its synchronous check

## Test plan
- [ ] Fresh page load with Xverse 2.0+ installed → wallet detected and connectable
- [ ] Fresh page load with Xverse 1.x → no regression, provider detected immediately (no added delay)
- [ ] Fresh page load without Xverse → app loads within ~2s (500ms existing delay + 1.5s timeout), Xverse correctly shown as not installed
- [ ] Clear browser cache + reload with Xverse 2.0+ → wallet still detected
- [ ] Other wallets (UniSat, OKX, Ledger Live) unaffected