### PR TITLE
fix dapp: fire-and-forget logging and wallet sign-in connector

### DIFF
--- a/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
+++ b/dapp/src/components/ConnectWalletModal/ConnectWalletButton.tsx
@@ -8,6 +8,7 @@ import React, {
 import { time } from "#/constants"
 import {
   useAppDispatch,
+  useConnector,
   useIsEmbed,
   useModal,
   usePostHogIdentity,
@@ -125,6 +126,7 @@ export default function ConnectWalletButton({
     onDisconnect,
     status: connectionStatus,
   } = useWallet()
+  const connectedConnector = useConnector()
   const { signMessageStatus, resetMessageStatus, signMessageAndCreateSession } =
     useSignMessageAndCreateSession()
   const { type, setConnectionAlert, resetConnectionAlert } =
@@ -178,19 +180,19 @@ export default function ConnectWalletButton({
 
       if (!btcAddress) return
 
-      await handleSignMessageAndCreateSession(connector, btcAddress)
+      await handleSignMessageAndCreateSession(connectedConnector, btcAddress)
       handleIdentification(btcAddress, {
         connector: connectedConnector.id,
       })
     },
-    [connector, handleSignMessageAndCreateSession, handleIdentification],
+    [handleSignMessageAndCreateSession, handleIdentification],
   )
 
   const handleConnection = useCallback(() => {
     onConnect(connector, {
       isReconnecting,
-      onSuccess: () => {
-        logPromiseFailure(onSuccessConnection(connector))
+      onSuccess: (walletConnector) => {
+        logPromiseFailure(onSuccessConnection(walletConnector))
       },
       onError: (error: OrangeKitError) => {
         const errorData = orangeKit.parseOrangeKitConnectionError(error)
@@ -335,8 +337,12 @@ export default function ConnectWalletButton({
                     size="lg"
                     variant="outline"
                     onClick={() =>
+                      connectedConnector &&
                       logPromiseFailure(
-                        handleSignMessageAndCreateSession(connector, address),
+                        handleSignMessageAndCreateSession(
+                          connectedConnector,
+                          address,
+                        ),
                       )
                     }
                   >

--- a/dapp/src/utils/logPromiseFailure.ts
+++ b/dapp/src/utils/logPromiseFailure.ts
@@ -1,12 +1,12 @@
 /**
- * If the promise fails, log the underlying error but maintain the failed
- * promise.
+ * Fire-and-forget helper: if the promise rejects, log it and do not rethrow.
  *
- * Does nothing to successful promises.
+ * Rethrowing inside `.catch()` would leave a second rejected promise that no
+ * caller awaits, which surfaces as an unhandled rejection in runtimes that
+ * enforce it.
  */
 export default function logPromiseFailure<T>(promise: Promise<T>) {
-  promise.catch((error) => {
+  void promise.catch((error: unknown) => {
     console.error(error)
-    throw error
   })
 }


### PR DESCRIPTION
hey team,

- quieted fire-and-forget logging so we don't rethrow after catch and trip unhandled rejections
- siww sign and retry now use the actually connected wallet connector from wagmi instead of the modal row connector

cheers