### PR TITLE
APY & Withdrawal Time Copy Updates

### DIFF
--- a/dapp/src/components/MidasVaultDetails.tsx
+++ b/dapp/src/components/MidasVaultDetails.tsx
@@ -77,8 +77,8 @@ export function getMidasVaultDetails({
         tooltip:
           "Annual Percentage Yield (APY) is the annual rate of return earned on an investment.",
         items: [
-          { label: "Gross Annual", value: "14% (est.)" },
-          { label: "Net Annual", value: "11% (est.)" },
+          { label: "Gross Annual", value: "4% (est.)" },
+          { label: "Net Annual", value: "3% (est.)" },
           { label: "Net Monthly", value: "0.87% (est.)" },
           { label: "Net Weekly", value: "0.20% (est.)" },
         ],

--- a/dapp/src/components/TransactionModal/ActionDurationEstimation.tsx
+++ b/dapp/src/components/TransactionModal/ActionDurationEstimation.tsx
@@ -7,7 +7,7 @@ import { TOKEN_AMOUNT_FIELD_NAME } from "../shared/TokenAmountForm/TokenAmountFo
 import TooltipIcon from "../shared/TooltipIcon"
 
 const TOOLTIP_CONTENT =
-  "Withdrawals are processed in the order they're requested. Completion can take up to 72 hours, depending on request volume, network conditions, and security checks."
+  "Withdrawals are processed in the order they're requested. Completion can take up to 14 days, depending on request volume, network conditions, and security checks."
 
 export default function ActionDurationEstimation({
   type,

--- a/dapp/src/components/TransactionModal/SuccessModal.tsx
+++ b/dapp/src/components/TransactionModal/SuccessModal.tsx
@@ -67,7 +67,7 @@ export default function SuccessModal({ type }: SuccessModalProps) {
           )}
           {ACTION_FLOW_TYPES.UNSTAKE === type && (
             <Text size="md">
-              Your BTC will appear in your wallet in 72 hours. Track the status
+              Your BTC will appear in your wallet in approximately 14 days. Track the status
               in your dashboard.
             </Text>
           )}

--- a/dapp/src/components/VaultDetailsModal.tsx
+++ b/dapp/src/components/VaultDetailsModal.tsx
@@ -164,7 +164,7 @@ export function VaultDetailsModalBase({
           <Icon as={IconShieldFilled} color="ink.50" />
           <Text size="xs">
             No centralized custodian. All on-chain. Rewards auto-compound to
-            Bitcoin daily.
+            Bitcoin every ~14 days.
           </Text>
         </Flex>
       </ModalBody>

--- a/dapp/src/components/WelcomeModal.tsx
+++ b/dapp/src/components/WelcomeModal.tsx
@@ -77,7 +77,7 @@ const steps = [
       <Highlight query="Acre Points Program">
         Deposit BTC to start earning. Monitor your position, review the vaults,
         earn with the Acre Points Program automatically, and redeem back into
-        Bitcoin at any time. Your bitcoin, on-chain, working for you.
+        Bitcoin within 14 days. Your bitcoin, on-chain, working for you.
       </Highlight>
     ),
     video: step3Video,

--- a/dapp/src/components/WithdrawalStatusBanner.tsx
+++ b/dapp/src/components/WithdrawalStatusBanner.tsx
@@ -15,7 +15,7 @@ export type WithdrawStatus = Extract<
 >
 
 const PENDING_STATE_TOOLTIP_CONTENT =
-  "Your withdrawal is being processed. The funds will be released and are expected to arrive in your wallet within approximately 72 hours."
+  "Your withdrawal is being processed. The funds will be released upon the next NAV update and are expected to arrive in your wallet within approximately 14 days."
 
 function EstimatedDurationText({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
Copy updates to change withdrawal time from 72 hours to approximately 14 days. 
Copy updates to change 11% net APY estimate to 3% net APY estimate. 