### PR TITLE
Temporarily pause withdrawals in dapp

### DIFF
--- a/dapp/src/pages/DashboardPage/PositionDetails.tsx
+++ b/dapp/src/pages/DashboardPage/PositionDetails.tsx
@@ -120,8 +120,7 @@ export default function PositionDetails() {
                     <br />
                     Withdrawals from the acreBTC vault are temporarily paused
                     while we complete an update. Your funds remain fully secure
-                    and under your control. Withdrawals will be re-enabled
-                    within the next 72 hours.
+                    and under your control.
                     <br />
                     <br />
                     Thank you for your patience as we finalize this upgrade.


### PR DESCRIPTION
## What

Temporarily pauses withdrawals in the dapp.

- The Withdraw button is disabled and shows the existing "Temporary Pause on Withdrawals" tooltip. This is driven by the existing `WITHDRAWALS_ENABLED` feature flag — to actually pause, set `VITE_FEATURE_FLAG_WITHDRAWALS_ENABLED=false` in the deploy environment (Netlify). No code toggle was added.
- Trimmed the tooltip copy to remove the "will be re-enabled within the next 72 hours" line so we don't commit to a re-enable timeframe.

## Notes

`.env.production`/`.env.staging` are gitignored and not part of this PR; the flag value is managed in the Netlify environment settings.